### PR TITLE
ci: adds script to run linters and checks

### DIFF
--- a/scripts/run_linters_and_checks.sh
+++ b/scripts/run_linters_and_checks.sh
@@ -5,7 +5,6 @@
 # to run linters and checks.
 main() {
   # As a default, run linters only. Add option to run checks
-  # checks = false;
   case $1 in
       -c|--checks) checks=true;
   esac

--- a/scripts/run_linters_and_checks.sh
+++ b/scripts/run_linters_and_checks.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# From the root directory, execute `./scripts/run_linters_and_checks.sh` to
+# run linters. Execute `./scripts/run_linters_and_checks.sh --checks`
+# to run linters and checks.
+main() {
+  # As a default, run linters only. Add option to run checks
+  # checks = false;
+  case $1 in
+      -c|--checks) checks=true;
+  esac
+
+  # Run linters
+  black . && isort .
+
+  # Optionally run style checks, docstring coverage, and test coverage.
+  # The results of the test coverage will additionally be saved to htmlcov.
+  if [ $checks ]
+  then
+    flake8 . && interrogate --verbose . && coverage run -m unittest discover
+    coverage report && coverage html
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Closes #12 

Bash script

- From aind-ephys-utils directory, run `./scripts/run_linters_and_checks.sh` to run linters only
- Run `./scripts/run_linters_and_checks.sh --checks` to run linters and style checks, docstring coverage checks, and test coverage checks.