### PR TITLE
feat: Extend `align` module to work with multiple units

### DIFF
--- a/src/aind_ephys_utils/align.py
+++ b/src/aind_ephys_utils/align.py
@@ -13,11 +13,19 @@ def to_events(  # noqa: C901
     interval,
     bin_size=None,
     event_labels=None,
-    return_dataframe=False,
+    unit_ids=None,
+    return_df=False,
+    spike_times_key="spike_times",
 ):
     """
     Aligns spikes times (sorted in ascending order) to
     a set of event times
+
+    Spike times can take the following formats:
+    - 1-dimensional ndarray of times for one unit
+    - list of 1-dimensional ndarrays of times for multiple units
+    - dict of 1-dimensional ndarrays with unit IDs as keys
+    - DataFrame indexed by unit IDs, with a "spike_times" column
 
     If the optional `bin_size` argument is supplied, the spike
     times are binned.
@@ -28,8 +36,8 @@ def to_events(  # noqa: C901
 
     Parameters
     ----------
-    times : ndarray
-        1-D sequence of times to align (in seconds). Must
+    times : ndarray, List[ndarrays], dict, or DataFrame
+        1-D sequence(s) of times to align (in seconds). Must
         be sorted in ascending order.
     events : ndarray
         1-D sequence of reference times (in seconds).
@@ -37,45 +45,69 @@ def to_events(  # noqa: C901
         Start and end of the window around each event (in seconds).
     bin_size : float, optional
         Bin size (in seconds); if None, then individual times will be returned.
+    unit_ids : List[int]
+        Labels for each unit. If len(unit_ids) < len(times) and times is
+        dict or DataFrame, then this argument will specify which units
+        to align.
     event_labels : List[int] or List[str]
         Labels for each event (optional).
-    return_dataframe : bool, optional (default = False)
+    return_df : bool, optional (default = False)
         If True, returns the results as a pandas DataFrame
         (or xarray.DataArray if binning is enabled).
+    spike_times_key : str, optional (default = 'spike_times')
+        If 'times' argument is a DataFrame, this specifies the name of the
+        column containing the spike times.
 
     Returns
     -------
-    if return_dataframe = False and bin_size = None:
+    if return_df = False and bin_size = None:
     aligned_times : ndarray
         1-D sequence of times relative to the events of interest.
     event_indices : ndarray
         1-D sequence of associated event index for each time in aligned_times.
+    unit_ids : list or ndarray
+        1-D sequence of unit IDs for each sequence of spike times
 
-    if return_dataframe = False and bin_size is not None:
+    if return_df = False and bin_size is not None:
     bins : ndarray
         1-D sequence of time bin left edges
     counts : ndarray
-        2-D array of spike counts of size trials x bins
+        2-D or 3-D array of spike counts of size trials x bins (x units)
+    unit_ids : ndarray
+        1-D sequence of unit IDs
 
-    if return_dataframe = True and bin_size = None:
+    if return_df = True and bin_size = None:
     df : pd.DataFrame with columns:
         - time : aligned times
         - event_index : event index for each time
         - event_label : event label for each time (optional)
+        - unit_id : unit label for each time (optional)
 
-    if return_dataframe = True and bin_size is not None:
+    if return_df = True and bin_size is not None:
     da : xr.DataArray with dimensions:
         - time : time relative to each event
         - event_index or event_label : label for each event
+        - unit_id : label of each unit
 
     """
 
+    if unit_ids is None:
+        if isinstance(times, np.ndarray):
+            unit_ids = [0]
+        elif isinstance(times, list):
+            unit_ids = np.arange(len(times))
+        elif isinstance(times, dict):
+            unit_ids = np.array(list(times.keys()))
+        elif isinstance(times, pd.DataFrame):
+            unit_ids = times.index.values
+
     if bin_size is not None:
         bins = np.arange(interval[0], interval[1] + bin_size, bin_size)
-        counts = np.zeros((bins.size - 1, events.size))
+        counts = np.zeros((bins.size - 1, events.size, len(unit_ids)))
 
     aligned_times = []
     event_indices = []
+    unit_labels = []
 
     if event_labels is not None:
         if len(event_labels) != len(events):
@@ -85,26 +117,45 @@ def to_events(  # noqa: C901
         labels = []
 
     for i, start in enumerate(events):
-        start_index = np.searchsorted(times, start + interval[0])
-        end_index = np.searchsorted(times, start + interval[1])
+        for j, unit in enumerate(unit_ids):
+            if isinstance(times, np.ndarray):
+                unit_times = times
+            elif isinstance(times, list):
+                unit_times = times[unit]
+            elif isinstance(times, dict):
+                unit_times = times[unit]
+            elif isinstance(times, pd.DataFrame):
+                unit_times = times.loc[unit][spike_times_key]
 
-        if bin_size is not None:
-            counts[:, i] = np.histogram(
-                times[start_index:end_index] - start, bins
-            )[0]
-        else:
-            aligned_times.append(times[start_index:end_index] - start)
-            event_indices.append(
-                np.zeros((end_index - start_index,), dtype="int") + i
-            )
-            if event_labels is not None:
-                labels.append([event_labels[i]] * (end_index - start_index))
+            start_index = np.searchsorted(unit_times, start + interval[0])
+            end_index = np.searchsorted(unit_times, start + interval[1])
 
-    if not return_dataframe:
+            if bin_size is not None:
+                counts[:, i, j] = np.histogram(
+                    unit_times[start_index:end_index] - start, bins
+                )[0]
+            else:
+                aligned_times.append(unit_times[start_index:end_index] - start)
+                event_indices.append(
+                    np.zeros((end_index - start_index,), dtype="int") + i
+                )
+                unit_labels.append(
+                    np.zeros((end_index - start_index,), dtype="int") + unit
+                )
+                if event_labels is not None:
+                    labels.append(
+                        [event_labels[i]] * (end_index - start_index)
+                    )
+
+    if not return_df:
         if bin_size is None:
-            return np.concatenate(aligned_times), np.concatenate(event_indices)
+            return (
+                np.concatenate(aligned_times),
+                np.concatenate(event_indices),
+                np.concatenate(unit_labels),
+            )
         else:
-            return bins[:-1], counts
+            return bins[:-1], np.squeeze(counts), unit_ids
     else:
         if bin_size is None:
             if event_labels is None:
@@ -112,6 +163,7 @@ def to_events(  # noqa: C901
                     data={
                         "time": np.concatenate(aligned_times),
                         "event_index": np.concatenate(event_indices),
+                        "unit_id": np.concatenate(unit_labels),
                     }
                 )
             else:
@@ -120,6 +172,7 @@ def to_events(  # noqa: C901
                         "time": np.concatenate(aligned_times),
                         "event_index": np.concatenate(event_indices),
                         "event_label": np.concatenate(labels),
+                        "unit_id": np.concatenate(unit_labels),
                     }
                 )
         else:
@@ -129,12 +182,17 @@ def to_events(  # noqa: C901
                     coords={
                         "time": bins[:-1],
                         "event_index": np.arange(len(events)),
+                        "unit_id": unit_ids,
                     },
                 )
             else:
                 return xr.DataArray(
                     data=counts,
-                    coords={"time": bins[:-1], "event_label": event_labels},
+                    coords={
+                        "time": bins[:-1],
+                        "event_label": event_labels,
+                        "unit_id": unit_ids,
+                    },
                 )
 
 

--- a/src/aind_ephys_utils/metrics.py
+++ b/src/aind_ephys_utils/metrics.py
@@ -60,7 +60,7 @@ def spike_latency(
     if use_psth:
         win = np.array([0, 0.25, 0.5, 0.25, 0])  # 5-point Hann window
 
-        bins, counts = align.to_events(
+        bins, counts, unit_ids = align.to_events(
             times, events, interval, bin_size=bin_size
         )
 
@@ -77,10 +77,8 @@ def spike_latency(
         return first_spike_latency * bin_size, psth
 
     else:
-        df = align.to_events(
-            times, events, (0, interval[1]), return_dataframe=True
-        )
+        df = align.to_events(times, events, (0, interval[1]), return_df=True)
 
-        latencies = np.squeeze(df.groupby("event_index").min().values)
+        latencies = np.squeeze(df.groupby("event_index").min()["time"].values)
 
         return np.median(latencies), latencies

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+import pandas as pd
 from numpy.testing import assert_array_equal
 
 from aind_ephys_utils.align import align_to_events, to_events
@@ -12,36 +13,38 @@ class AlignSpikesTest(unittest.TestCase):
     """Tests spike alignment methods."""
 
     events = np.arange(10)  # 10 events
-    times = events
     labels = np.arange(10) + 1  # event labels
+    times = events
+    unit_ids = np.arange(10)  # 10 units
 
-    def test_align(self) -> None:
-        """Test the `align` method."""
+    def test_align_ndarray(self) -> None:
+        """Test the `align` method with ndarray as input"""
 
-        ts, inds = to_events(self.times, self.events, (-0.1, 0.1))
+        ts, inds, units = to_events(self.times, self.events, (-0.1, 0.1))
 
         assert_array_equal(ts, np.zeros(self.times.shape))
         assert_array_equal(inds, np.arange(10, dtype="int"))
+        assert_array_equal(units, np.zeros(self.times.shape))
 
-        df = to_events(
-            self.times, self.events, (-0.1, 0.1), return_dataframe=True
-        )
+        df = to_events(self.times, self.events, (-0.1, 0.1), return_df=True)
 
         assert_array_equal(df.time, np.zeros(self.times.shape))
         assert_array_equal(df.event_index, np.arange(10, dtype="int"))
+        assert_array_equal(df.unit_id, np.zeros(self.times.shape))
 
         df = to_events(
             self.times,
             self.events,
             (-0.1, 0.1),
             event_labels=self.labels,
-            return_dataframe=True,
+            return_df=True,
         )
 
         assert_array_equal(df.time, np.zeros(self.times.shape))
         assert_array_equal(df.event_index, np.arange(10, dtype="int"))
+        assert_array_equal(df.unit_id, np.zeros(self.times.shape))
 
-        bins, counts = to_events(
+        bins, counts, unit_ids = to_events(
             self.times, self.events, (-0.1, 0.1), bin_size=0.01
         )
 
@@ -52,7 +55,7 @@ class AlignSpikesTest(unittest.TestCase):
             self.events,
             (-0.1, 0.1),
             bin_size=0.01,
-            return_dataframe=True,
+            return_df=True,
         )
 
         self.assertEqual(np.sum(da.data), len(self.events))
@@ -63,7 +66,7 @@ class AlignSpikesTest(unittest.TestCase):
             (-0.1, 0.1),
             bin_size=0.01,
             event_labels=self.labels,
-            return_dataframe=True,
+            return_df=True,
         )
 
         self.assertEqual(np.sum(da.data), len(self.events))
@@ -75,7 +78,7 @@ class AlignSpikesTest(unittest.TestCase):
                 (-0.1, 0.1),
                 bin_size=0.01,
                 event_labels=self.labels[:5],
-                return_dataframe=True,
+                return_df=True,
             )
 
         self.assertTrue(
@@ -83,10 +86,195 @@ class AlignSpikesTest(unittest.TestCase):
             in str(context.exception)
         )
 
+    def test_align_list(self) -> None:
+        """Test the `align` method with a list of times as input"""
+
+        times_as_list = [self.times for unit in self.unit_ids]
+
+        ts, inds, units = to_events(times_as_list, self.events, (-0.1, 0.1))
+
+        assert_array_equal(
+            ts,
+            np.concatenate(
+                [np.zeros(self.times.shape) for i in self.unit_ids]
+            ),
+        )
+        assert_array_equal(
+            units, np.concatenate([self.unit_ids for i in self.events])
+        )
+        assert_array_equal(
+            inds,
+            np.concatenate(
+                [np.zeros(self.unit_ids.shape) + i for i in self.events]
+            ),
+        )
+
+        df = to_events(times_as_list, self.events, (-0.1, 0.1), return_df=True)
+
+        assert_array_equal(
+            df.time,
+            np.concatenate(
+                [np.zeros(self.times.shape) for i in self.unit_ids]
+            ),
+        )
+        assert_array_equal(
+            df.unit_id, np.concatenate([self.unit_ids for i in self.events])
+        )
+        assert_array_equal(
+            df.event_index,
+            np.concatenate(
+                [np.zeros(self.unit_ids.shape) + i for i in self.events]
+            ),
+        )
+
+        bins, counts, unit_ids = to_events(
+            times_as_list, self.events, (-0.1, 0.1), bin_size=0.01
+        )
+
+        self.assertEqual(np.sum(counts), len(self.events) * len(self.unit_ids))
+
+        da = to_events(
+            times_as_list,
+            self.events,
+            (-0.1, 0.1),
+            bin_size=0.01,
+            return_df=True,
+        )
+
+        self.assertEqual(
+            np.sum(da.data), len(self.events) * len(self.unit_ids)
+        )
+
+    def test_align_dict(self) -> None:
+        """Test the `align` method with a dict of spike times as input"""
+
+        times_as_dict = {}
+
+        for i in self.unit_ids:
+            times_as_dict[i] = self.times
+
+        ts, inds, units = to_events(times_as_dict, self.events, (-0.1, 0.1))
+
+        assert_array_equal(
+            ts,
+            np.concatenate(
+                [np.zeros(self.times.shape) for i in self.unit_ids]
+            ),
+        )
+        assert_array_equal(
+            units, np.concatenate([self.unit_ids for i in self.events])
+        )
+        assert_array_equal(
+            inds,
+            np.concatenate(
+                [np.zeros(self.unit_ids.shape) + i for i in self.events]
+            ),
+        )
+
+        df = to_events(times_as_dict, self.events, (-0.1, 0.1), return_df=True)
+
+        assert_array_equal(
+            df.time,
+            np.concatenate(
+                [np.zeros(self.times.shape) for i in self.unit_ids]
+            ),
+        )
+        assert_array_equal(
+            df.unit_id, np.concatenate([self.unit_ids for i in self.events])
+        )
+        assert_array_equal(
+            df.event_index,
+            np.concatenate(
+                [np.zeros(self.unit_ids.shape) + i for i in self.events]
+            ),
+        )
+
+        bins, counts, unit_ids = to_events(
+            times_as_dict, self.events, (-0.1, 0.1), bin_size=0.01
+        )
+
+        self.assertEqual(np.sum(counts), len(self.events) * len(self.unit_ids))
+
+        da = to_events(
+            times_as_dict,
+            self.events,
+            (-0.1, 0.1),
+            bin_size=0.01,
+            return_df=True,
+        )
+
+        self.assertEqual(
+            np.sum(da.data), len(self.events) * len(self.unit_ids)
+        )
+
+    def test_align_df(self) -> None:
+        """Test the `align` method with a DataFrame of spike times as input"""
+
+        times_as_list = [self.times for unit in self.unit_ids]
+        times_as_df = pd.DataFrame(
+            index=self.unit_ids, data={"spike_times": times_as_list}
+        )
+
+        ts, inds, units = to_events(times_as_df, self.events, (-0.1, 0.1))
+
+        assert_array_equal(
+            ts,
+            np.concatenate(
+                [np.zeros(self.times.shape) for i in self.unit_ids]
+            ),
+        )
+        assert_array_equal(
+            units, np.concatenate([self.unit_ids for i in self.events])
+        )
+        assert_array_equal(
+            inds,
+            np.concatenate(
+                [np.zeros(self.unit_ids.shape) + i for i in self.events]
+            ),
+        )
+
+        df = to_events(times_as_df, self.events, (-0.1, 0.1), return_df=True)
+
+        assert_array_equal(
+            df.time,
+            np.concatenate(
+                [np.zeros(self.times.shape) for i in self.unit_ids]
+            ),
+        )
+        assert_array_equal(
+            df.unit_id, np.concatenate([self.unit_ids for i in self.events])
+        )
+        assert_array_equal(
+            df.event_index,
+            np.concatenate(
+                [np.zeros(self.unit_ids.shape) + i for i in self.events]
+            ),
+        )
+
+        bins, counts, unit_ids = to_events(
+            times_as_df, self.events, (-0.1, 0.1), bin_size=0.01
+        )
+
+        self.assertEqual(np.sum(counts), len(self.events) * len(self.unit_ids))
+
+        da = to_events(
+            times_as_df,
+            self.events,
+            (-0.1, 0.1),
+            bin_size=0.01,
+            return_df=True,
+        )
+
+        self.assertEqual(
+            np.sum(da.data), len(self.events) * len(self.unit_ids)
+        )
+
     def test_align_to_events(self) -> None:
         """Test the `align_to_events` alias"""
 
-        ts, inds = align_to_events(self.times, self.events, (-0.1, 0.1))
+        ts, inds, unit_ids = align_to_events(
+            self.times, self.events, (-0.1, 0.1)
+        )
 
         assert_array_equal(ts, np.zeros(self.times.shape))
         assert_array_equal(inds, np.arange(10, dtype="int"))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -26,6 +26,8 @@ class SpikeLatencyTest(unittest.TestCase):
             self.times, self.events, (-0.1, 0.1), use_psth=False
         )
 
+        print(latencies)
+
         assert_allclose(first_spike, self.offset)
         assert_array_equal(latencies, self.times - self.events)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -26,8 +26,6 @@ class SpikeLatencyTest(unittest.TestCase):
             self.times, self.events, (-0.1, 0.1), use_psth=False
         )
 
-        print(latencies)
-
         assert_allclose(first_spike, self.offset)
         assert_array_equal(latencies, self.times - self.events)
 

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -21,7 +21,7 @@ class SortingTest(unittest.TestCase):
         events,
         interval=(-1, 1),
         event_labels=labels,
-        return_dataframe=True,
+        return_df=True,
     )
 
     def test_by_condition(self) -> None:


### PR DESCRIPTION
These changes modify the `align` module to allow it to accept multiple spike trains as input data, to efficiently align the data for many units at once.

It still works with a spike train for a single unit, but now also works with the following data types:
- A list of `ndarrays`, with one item for each unit
- A dict of `ndarrays`, with one key for each unit; this is how the AllenSDK `EcephysSession` object returns spike times
- A `DataFrame` with one row for each unit and a column (e.g. `spike_times`) containing spike times; this is how `pynwb` returns spike times

I've also changed the name of an input argument from `return_dataframe` to `return_df` for brevity, and added an extra return value to represent unit IDs (only in the case where `return_df` is set to `False`).