### PR TITLE
draft of core, xarray separation

### DIFF
--- a/src/aind_ephys_utils/adapters/__init__.py
+++ b/src/aind_ephys_utils/adapters/__init__.py
@@ -1,9 +1,21 @@
-"""Adapters for converting common data formats into xarray objects.
+"""Adapters for converting between common data formats and canonical types.
 
-Adapters are responsible for building canonical xarray representations used by
-`.ephys` methods.
+Adapters are responsible for building canonical representations used by
+``.ephys`` methods and the :mod:`~aind_ephys_utils.types` dataclass types.
 """
 
 from .dataframe import from_dataframe
+from .xarray import (
+    binned_to_xarray,
+    ragged_to_xarray,
+    xarray_to_binned,
+    xarray_to_ragged,
+)
 
-__all__ = ["from_dataframe"]
+__all__ = [
+    "from_dataframe",
+    "binned_to_xarray",
+    "ragged_to_xarray",
+    "xarray_to_binned",
+    "xarray_to_ragged",
+]

--- a/src/aind_ephys_utils/adapters/xarray.py
+++ b/src/aind_ephys_utils/adapters/xarray.py
@@ -1,0 +1,175 @@
+"""xarray <-> dataclass type conversions.
+
+Provides conversion between :class:`~aind_ephys_utils.types.BinnedSpikes`
+/ :class:`~aind_ephys_utils.types.RaggedSpikes` and ``xr.DataArray``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+from ..standards.conventions import C
+from ..types import BinnedSpikes, RaggedSpikes
+
+
+def binned_to_xarray(binned: BinnedSpikes) -> xr.DataArray:
+    """Convert :class:`BinnedSpikes` to ``xr.DataArray``.
+
+    Parameters
+    ----------
+    binned : BinnedSpikes
+
+    Returns
+    -------
+    xr.DataArray
+        Dims ``(trial, unit, time)``. Coordinates include trial/unit/time
+        index coords plus all entries from ``trial_meta`` and
+        ``unit_meta``.
+    """
+    coords: dict = {
+        C.trial: np.arange(binned.n_trials),
+        C.unit: np.arange(binned.n_units),
+        C.time: binned.time,
+    }
+    # Use unit_id as the unit coordinate if available.
+    if "unit_id" in binned.unit_meta:
+        coords[C.unit] = binned.unit_meta["unit_id"]
+
+    # Attach remaining metadata as non-index coords.
+    for key, arr in binned.trial_meta.items():
+        coords[key] = (C.trial, arr)
+    for key, arr in binned.unit_meta.items():
+        if key != "unit_id":
+            coords[key] = (C.unit, arr)
+
+    return xr.DataArray(
+        data=binned.data,
+        dims=(C.trial, C.unit, C.time),
+        coords=coords,
+    )
+
+
+def xarray_to_binned(da: xr.DataArray) -> BinnedSpikes:
+    """Convert ``xr.DataArray`` to :class:`BinnedSpikes`.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Must have dims that include ``"trial"``, ``"unit"``, ``"time"``.
+        Transposed to ``(trial, unit, time)`` if needed.
+
+    Returns
+    -------
+    BinnedSpikes
+    """
+    da = da.transpose(C.trial, C.unit, C.time)
+    data = da.values.astype(np.float64)
+    time = np.asarray(da[C.time].values, dtype=np.float64)
+
+    trial_meta: dict[str, np.ndarray] = {}
+    unit_meta: dict[str, np.ndarray] = {}
+    for name, coord in da.coords.items():
+        if name in (C.trial, C.unit, C.time):
+            continue
+        if coord.dims == (C.trial,):
+            trial_meta[str(name)] = np.asarray(coord.values)
+        elif coord.dims == (C.unit,):
+            unit_meta[str(name)] = np.asarray(coord.values)
+
+    return BinnedSpikes(
+        data=data,
+        time=time,
+        trial_meta=trial_meta,
+        unit_meta=unit_meta,
+    )
+
+
+def ragged_to_xarray(ragged: RaggedSpikes) -> xr.DataArray:
+    """Convert :class:`RaggedSpikes` to ``xr.DataArray`` (object dtype).
+
+    Parameters
+    ----------
+    ragged : RaggedSpikes
+
+    Returns
+    -------
+    xr.DataArray
+        Dims ``(trial, unit)``, dtype=object. Each cell contains a 1-D
+        float array of spike times.
+    """
+    data = np.empty((ragged.n_trials, ragged.n_units), dtype=object)
+    for t in range(ragged.n_trials):
+        for u in range(ragged.n_units):
+            data[t, u] = ragged.spike_times[t][u]
+
+    coords: dict = {
+        C.trial: np.arange(ragged.n_trials),
+        C.unit: np.arange(ragged.n_units),
+    }
+    if "unit_id" in ragged.unit_meta:
+        coords[C.unit] = ragged.unit_meta["unit_id"]
+
+    for key, arr in ragged.trial_meta.items():
+        coords[key] = (C.trial, arr)
+    for key, arr in ragged.unit_meta.items():
+        if key != "unit_id":
+            coords[key] = (C.unit, arr)
+
+    da = xr.DataArray(data=data, dims=(C.trial, C.unit), coords=coords)
+    if ragged.time_window is not None:
+        da.attrs[C.attr_valid_intervals] = [ragged.time_window]
+    return da
+
+
+def xarray_to_ragged(da: xr.DataArray) -> RaggedSpikes:
+    """Convert ``xr.DataArray`` (object dtype) to :class:`RaggedSpikes`.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Must have dims ``(trial, unit)`` and ``dtype=object``.
+
+    Returns
+    -------
+    RaggedSpikes
+    """
+    da = da.transpose(C.trial, C.unit)
+    n_trials, n_units = da.shape
+
+    spike_times: list[list[np.ndarray]] = []
+    for t in range(n_trials):
+        trial_spikes = []
+        for u in range(n_units):
+            val = da.values[t, u]
+            if val is None:
+                trial_spikes.append(np.array([], dtype=np.float64))
+            else:
+                trial_spikes.append(np.asarray(val, dtype=np.float64))
+        spike_times.append(trial_spikes)
+
+    # Extract metadata from non-index coords.
+    trial_meta: dict[str, np.ndarray] = {}
+    unit_meta: dict[str, np.ndarray] = {}
+    for name, coord in da.coords.items():
+        if name in (C.trial, C.unit):
+            continue
+        if coord.dims == (C.trial,):
+            trial_meta[str(name)] = np.asarray(coord.values)
+        elif coord.dims == (C.unit,):
+            unit_meta[str(name)] = np.asarray(coord.values)
+
+    window = None
+    if C.attr_valid_intervals in da.attrs:
+        intervals = da.attrs[C.attr_valid_intervals]
+        if intervals:
+            window = tuple(intervals[0])
+
+    return RaggedSpikes(
+        spike_times=spike_times,
+        n_trials=n_trials,
+        n_units=n_units,
+        time_window=window,
+        trial_meta=trial_meta,
+        unit_meta=unit_meta,
+    )

--- a/src/aind_ephys_utils/core/__init__.py
+++ b/src/aind_ephys_utils/core/__init__.py
@@ -1,0 +1,34 @@
+"""Pure numpy core operations for electrophysiology analysis.
+
+This package contains no xarray dependency. All functions operate on
+plain numpy arrays with a fixed axis convention:
+
+- **Dense data**: always ``(trial, unit, time)``
+- **Ragged data**: ``spike_times[trial][unit]`` -> 1-D float array
+
+No ``dim=`` parameters. Every function knows which axis is which.
+"""
+
+from .align import align, align_unit
+from .baseline import baseline
+from .bin import bin_spikes, make_bin_edges
+from .normalize import normalize
+from .psth import psth
+from .restrict import restrict_dense, restrict_ragged
+from .smooth import convolve_1d, infer_dt, make_kernel, smooth
+
+__all__ = [
+    "align",
+    "align_unit",
+    "baseline",
+    "bin_spikes",
+    "convolve_1d",
+    "infer_dt",
+    "make_bin_edges",
+    "make_kernel",
+    "normalize",
+    "psth",
+    "restrict_dense",
+    "restrict_ragged",
+    "smooth",
+]

--- a/src/aind_ephys_utils/core/align.py
+++ b/src/aind_ephys_utils/core/align.py
@@ -1,0 +1,99 @@
+"""Spike alignment -- pure numpy, no xarray."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def align_unit(
+    spike_times: NDArray[np.float64],
+    anchor_times: NDArray[np.float64],
+    window: tuple[float, float],
+) -> list[NDArray[np.float64]]:
+    """Align one unit's spikes to per-trial anchor times.
+
+    Uses vectorized ``searchsorted`` to find spike boundaries for all
+    trials simultaneously, then slices per trial.
+
+    Parameters
+    ----------
+    spike_times : ndarray, shape (n_spikes,)
+        Sorted spike times for a single unit (session time).
+    anchor_times : ndarray, shape (n_trials,)
+        Per-trial anchor times (e.g. stimulus onset times).
+    window : (float, float)
+        ``(tmin, tmax)`` relative to anchor. E.g. ``(-0.5, 1.0)``.
+
+    Returns
+    -------
+    list of ndarray
+        Length ``n_trials``. Each element is a 1-D float array of spike
+        times relative to the anchor.
+    """
+    tmin, tmax = window
+    n_trials = len(anchor_times)
+
+    if spike_times is None:
+        return [np.array([], dtype=float) for _ in range(n_trials)]
+
+    arr = np.asarray(spike_times, dtype=float)
+    if arr.size == 0:
+        return [np.array([], dtype=float) for _ in range(n_trials)]
+
+    # Vectorized searchsorted: find all boundaries at once.
+    lo_bounds = anchor_times + tmin
+    hi_bounds = anchor_times + tmax
+    all_lo = np.searchsorted(arr, lo_bounds)
+    all_hi = np.searchsorted(arr, hi_bounds)
+
+    # Slice and shift for each trial (can't vectorize due to ragged output).
+    result = []
+    for i in range(n_trials):
+        result.append(arr[all_lo[i] : all_hi[i]] - anchor_times[i])
+
+    return result
+
+
+def align(
+    spike_times: list[NDArray[np.float64]],
+    anchor_times: NDArray[np.float64],
+    window: tuple[float, float],
+) -> list[list[NDArray[np.float64]]]:
+    """Align spikes for all units to per-trial anchor times.
+
+    Parameters
+    ----------
+    spike_times : list of ndarray
+        Length ``n_units``. ``spike_times[u]`` is a sorted 1-D float
+        array of spike times for unit *u* (session time).
+    anchor_times : ndarray, shape (n_trials,)
+        Per-trial anchor times.
+    window : (float, float)
+        ``(tmin, tmax)`` relative to anchor.
+
+    Returns
+    -------
+    list of list of ndarray
+        Outer list has length ``n_trials``, inner list has length
+        ``n_units``. Each element is a 1-D float array of aligned
+        spike times.
+    """
+    tmin, tmax = window
+    if tmin >= tmax:
+        raise ValueError(f"window must be (tmin, tmax) with tmin < tmax, got {window}.")
+
+    anchor_times = np.asarray(anchor_times, dtype=float)
+    n_units = len(spike_times)
+    n_trials = len(anchor_times)
+
+    # Align per unit: unit_results[u] is list of n_trials arrays.
+    unit_results = [
+        align_unit(spike_times[u], anchor_times, window) for u in range(n_units)
+    ]
+
+    # Transpose to [trial][unit].
+    result: list[list[NDArray[np.float64]]] = [
+        [unit_results[u][t] for u in range(n_units)] for t in range(n_trials)
+    ]
+    return result

--- a/src/aind_ephys_utils/core/baseline.py
+++ b/src/aind_ephys_utils/core/baseline.py
@@ -1,0 +1,69 @@
+"""Baseline correction -- pure numpy, no xarray."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def baseline(
+    data: NDArray[np.float64],
+    time: NDArray[np.float64],
+    window: tuple[float, float],
+    *,
+    mode: str = "subtract",
+) -> NDArray[np.float64]:
+    """Apply baseline correction over a time window.
+
+    Operates along the last axis (time). For the standard
+    ``(trial, unit, time)`` layout, this means the baseline
+    statistics are computed per trial-unit pair.
+
+    Parameters
+    ----------
+    data : ndarray, shape (..., n_time)
+        Dense data array.
+    time : ndarray, shape (n_time,)
+        Time coordinate values.
+    window : (float, float)
+        ``(tmin, tmax)`` baseline window. Selects time points where
+        ``tmin <= time <= tmax``.
+    mode : str
+        ``"subtract"`` (default), ``"divide"``, or ``"zscore"``.
+
+    Returns
+    -------
+    ndarray, same shape as *data*
+        Baseline-corrected data.
+
+    Raises
+    ------
+    ValueError
+        If window is invalid, produces no samples, or mode is unknown.
+    """
+    tmin, tmax = window
+    if tmin >= tmax:
+        raise ValueError(f"window must have tmin < tmax, got {window}.")
+
+    mask = (time >= tmin) & (time <= tmax)
+    if not mask.any():
+        raise ValueError("Baseline window produced no samples.")
+
+    # baseline_data shape: (..., n_baseline_bins)
+    baseline_data = data[..., mask]
+    mean = baseline_data.mean(axis=-1, keepdims=True)
+
+    mode = mode.lower()
+    if mode == "subtract":
+        return data - mean
+    elif mode == "divide":
+        return data / mean
+    elif mode == "zscore":
+        std = baseline_data.std(axis=-1, keepdims=True)
+        # Guard against division by zero.
+        safe_std = np.where(std == 0, 1.0, std)
+        out = (data - mean) / safe_std
+        # Where std was 0, the signal is constant → baselined value is 0.
+        return np.where(std == 0, 0.0, out)
+    else:
+        raise ValueError(f"Unknown baseline mode {mode!r}.")

--- a/src/aind_ephys_utils/core/bin.py
+++ b/src/aind_ephys_utils/core/bin.py
@@ -1,0 +1,114 @@
+"""Binning operations -- pure numpy, no xarray."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def make_bin_edges(
+    dt: float,
+    window: tuple[float, float],
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Compute bin edges and centers for a given window and bin width.
+
+    Parameters
+    ----------
+    dt : float
+        Bin width in seconds. Must be positive.
+    window : (float, float)
+        ``(tmin, tmax)`` time window.
+
+    Returns
+    -------
+    edges : ndarray, shape (n_bins + 1,)
+        Bin edges.
+    centers : ndarray, shape (n_bins,)
+        Bin centers.
+    """
+    if dt <= 0:
+        raise ValueError("dt must be positive.")
+    tmin, tmax = window
+    if tmin >= tmax:
+        raise ValueError(f"window must have tmin < tmax, got {window}.")
+
+    ratio = (tmax - tmin) / dt
+    if np.isclose(ratio, round(ratio)):
+        n_bins = int(round(ratio))
+    else:
+        n_bins = int(np.ceil(ratio))
+    n_bins = max(1, n_bins)
+
+    edges = tmin + dt * np.arange(n_bins + 1, dtype=float)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    return edges, centers
+
+
+def bin_spikes(
+    spike_times: list[list[NDArray[np.float64]]],
+    dt: float,
+    window: tuple[float, float],
+    *,
+    output: str = "rate",
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Bin ragged spikes into a dense (trial, unit, time) array.
+
+    Parameters
+    ----------
+    spike_times : list of list of ndarray
+        ``spike_times[trial][unit]`` is a 1-D float array of spike
+        times.
+    dt : float
+        Bin width in seconds.
+    window : (float, float)
+        ``(tmin, tmax)`` time window for binning.
+    output : str
+        ``"rate"`` (spikes/s) or ``"count"`` (raw counts).
+
+    Returns
+    -------
+    data : ndarray, shape (n_trials, n_units, n_bins)
+        Binned spike data.
+    centers : ndarray, shape (n_bins,)
+        Time bin centers.
+
+    Raises
+    ------
+    ValueError
+        If *dt* <= 0, window is invalid, or *output* is not recognized.
+    """
+    output = output.lower()
+    if output not in ("rate", "count"):
+        raise ValueError("output must be 'rate' or 'count'.")
+
+    edges, centers = make_bin_edges(dt, window)
+
+    n_trials = len(spike_times)
+    n_units = len(spike_times[0]) if n_trials > 0 else 0
+    n_bins = len(centers)
+
+    data = np.zeros((n_trials, n_units, n_bins), dtype=np.float64)
+    for t in range(n_trials):
+        for u in range(n_units):
+            arr = _ensure_1d_float(spike_times[t][u])
+            if arr.size > 0:
+                data[t, u], _ = np.histogram(arr, bins=edges)
+
+    if output == "rate":
+        data = data / dt
+
+    return data, centers
+
+
+def _ensure_1d_float(x: object) -> NDArray[np.float64]:
+    """Coerce a spike-time entry to a 1-D float array."""
+    if x is None:
+        return np.array([], dtype=np.float64)
+    arr = np.asarray(x, dtype=np.float64)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    if arr.ndim != 1:
+        raise ValueError(
+            f"Spike time entries must be 0-D or 1-D, got shape {arr.shape}."
+        )
+    return arr

--- a/src/aind_ephys_utils/core/normalize.py
+++ b/src/aind_ephys_utils/core/normalize.py
@@ -1,0 +1,72 @@
+"""Normalization operations -- pure numpy, no xarray."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+# Fixed mapping from semantic names to axis indices.
+# Convention: data is always (trial, unit, time).
+# The xarray layer uses ``dim=`` (xarray convention); this layer uses
+# ``across=`` to avoid confusion with numpy axis integers.
+AXIS_MAP: dict[str, int] = {"trials": 0, "units": 1, "time": 2}
+
+
+def normalize(
+    data: NDArray[np.float64],
+    *,
+    across: str | tuple[str, ...] = "trials",
+    method: str = "zscore",
+) -> NDArray[np.float64]:
+    """Normalize data across one or more axes.
+
+    Parameters
+    ----------
+    data : ndarray, shape (n_trials, n_units, n_time)
+        Dense data array.
+    across : str or tuple of str
+        Axis name(s) to normalize across. Valid names: ``"trials"``,
+        ``"units"``, ``"time"``, or a tuple combining them.
+    method : str
+        ``"zscore"``, ``"minmax"``, or ``"robust"``.
+
+    Returns
+    -------
+    ndarray, same shape as *data*
+        Normalized data. Zero-variance slices are set to 0.
+    """
+    if isinstance(across, str):
+        across = (across,)
+
+    try:
+        axes = tuple(AXIS_MAP[a] for a in across)
+    except KeyError:
+        bad = [a for a in across if a not in AXIS_MAP]
+        raise ValueError(
+            f"Unknown axis name(s): {bad}. Valid names: {list(AXIS_MAP.keys())}."
+        )
+
+    method = method.lower()
+    if method == "zscore":
+        mean = np.mean(data, axis=axes, keepdims=True)
+        std = np.std(data, axis=axes, keepdims=True)
+        safe_std = np.where(std == 0, 1.0, std)
+        out = (data - mean) / safe_std
+        return np.where(std == 0, 0.0, out)
+    elif method == "minmax":
+        vmin = np.min(data, axis=axes, keepdims=True)
+        vmax = np.max(data, axis=axes, keepdims=True)
+        denom = vmax - vmin
+        safe_denom = np.where(denom == 0, 1.0, denom)
+        out = (data - vmin) / safe_denom
+        return np.where(denom == 0, 0.0, out)
+    elif method == "robust":
+        q25 = np.quantile(data, 0.25, axis=axes, keepdims=True)
+        q75 = np.quantile(data, 0.75, axis=axes, keepdims=True)
+        median = np.quantile(data, 0.5, axis=axes, keepdims=True)
+        iqr = q75 - q25
+        safe_iqr = np.where(iqr == 0, 1.0, iqr)
+        out = (data - median) / safe_iqr
+        return np.where(iqr == 0, 0.0, out)
+    else:
+        raise ValueError(f"Unknown normalization method {method!r}.")

--- a/src/aind_ephys_utils/core/psth.py
+++ b/src/aind_ephys_utils/core/psth.py
@@ -1,0 +1,55 @@
+"""PSTH operations -- pure numpy, no xarray."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def psth(
+    data: NDArray[np.float64],
+    *,
+    method: str = "mean",
+    labels: NDArray | None = None,
+) -> NDArray[np.float64] | tuple[NDArray[np.float64], NDArray]:
+    """Reduce across trials (axis 0) to compute a PSTH.
+
+    Parameters
+    ----------
+    data : ndarray, shape (n_trials, ...)
+        Dense data. First axis is trials.
+    method : str
+        ``"mean"`` or ``"median"``.
+    labels : ndarray, shape (n_trials,), optional
+        Per-trial group labels. If provided, returns one summary per
+        unique label.
+
+    Returns
+    -------
+    If *labels* is ``None``:
+        ndarray, shape ``data.shape[1:]``
+            Trial-averaged data.
+    If *labels* is provided:
+        ``(result, unique_labels)`` where *result* has shape
+        ``(n_groups, *data.shape[1:])`` and *unique_labels* has shape
+        ``(n_groups,)``.
+    """
+    method = method.lower()
+    if method not in ("mean", "median"):
+        raise ValueError(f"Unknown PSTH method {method!r}.")
+
+    reduce_fn = np.mean if method == "mean" else np.median
+
+    if labels is None:
+        return reduce_fn(data, axis=0)
+
+    labels = np.asarray(labels)
+    unique = np.unique(labels)
+    n_groups = len(unique)
+
+    result = np.empty((n_groups,) + data.shape[1:], dtype=data.dtype)
+    for i, lbl in enumerate(unique):
+        mask = labels == lbl
+        result[i] = reduce_fn(data[mask], axis=0)
+
+    return result, unique

--- a/src/aind_ephys_utils/core/restrict.py
+++ b/src/aind_ephys_utils/core/restrict.py
@@ -1,0 +1,71 @@
+"""Restrict operations -- pure numpy, no xarray."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def restrict_dense(
+    data: NDArray[np.float64],
+    time: NDArray[np.float64],
+    window: tuple[float, float],
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Restrict dense data to a time window.
+
+    Parameters
+    ----------
+    data : ndarray, shape (..., n_time)
+        Dense data with time along the last axis.
+    time : ndarray, shape (n_time,)
+        Time coordinate values.
+    window : (float, float)
+        ``(tmin, tmax)`` interval to keep (inclusive).
+
+    Returns
+    -------
+    data_restricted : ndarray, shape (..., n_kept)
+        Restricted data.
+    time_restricted : ndarray, shape (n_kept,)
+        Restricted time values.
+    """
+    tmin, tmax = window
+    # Unlike baseline/bin/align which require positive-width windows,
+    # restrict allows tmin == tmax to select a single time point.
+    if tmin > tmax:
+        raise ValueError(f"window must have tmin <= tmax, got {window}.")
+    mask = (time >= tmin) & (time <= tmax)
+    return data[..., mask], time[mask]
+
+
+def restrict_ragged(
+    spike_times: list[list[NDArray[np.float64]]],
+    window: tuple[float, float],
+) -> list[list[NDArray[np.float64]]]:
+    """Restrict ragged spikes to a time window.
+
+    Parameters
+    ----------
+    spike_times : list of list of ndarray
+        ``spike_times[trial][unit]`` is a sorted 1-D float array.
+    window : (float, float)
+        ``(tmin, tmax)`` interval to keep.
+
+    Returns
+    -------
+    list of list of ndarray
+        Same structure, with spikes outside window removed.
+    """
+    tmin, tmax = window
+    if tmin > tmax:
+        raise ValueError(f"window must have tmin <= tmax, got {window}.")
+    result = []
+    for trial_spikes in spike_times:
+        trial_result = []
+        for arr in trial_spikes:
+            arr = np.asarray(arr, dtype=float)
+            left = np.searchsorted(arr, tmin, side="left")
+            right = np.searchsorted(arr, tmax, side="right")
+            trial_result.append(arr[left:right])
+        result.append(trial_result)
+    return result

--- a/src/aind_ephys_utils/core/smooth.py
+++ b/src/aind_ephys_utils/core/smooth.py
@@ -1,0 +1,204 @@
+"""Smoothing operations -- pure numpy, no xarray."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def infer_dt(time: NDArray[np.float64]) -> float:
+    """Infer uniform sampling interval from a 1-D time array.
+
+    Parameters
+    ----------
+    time : ndarray, shape (n_time,)
+        Monotonically increasing, uniformly spaced time values.
+
+    Returns
+    -------
+    float
+        The sampling interval dt.
+
+    Raises
+    ------
+    ValueError
+        If fewer than 2 values, non-uniform spacing, or non-increasing.
+    """
+    values = np.asarray(time, dtype=float)
+    if values.ndim != 1 or values.size < 2:
+        raise ValueError("Need at least two coordinate values to infer dt.")
+    diffs = np.diff(values)
+    dt = float(diffs[0])
+    if not np.allclose(diffs, dt):
+        raise ValueError("Coordinate values must be uniformly spaced.")
+    if dt <= 0:
+        raise ValueError("Coordinate values must be increasing.")
+    return dt
+
+
+def make_kernel(
+    method: str,
+    dt: float,
+    *,
+    sigma: float | None = None,
+    window: float | None = None,
+) -> NDArray[np.float64]:
+    """Build a normalized 1-D smoothing kernel.
+
+    Parameters
+    ----------
+    method : str
+        One of "gaussian", "boxcar" (aliases: "mean", "moving").
+    dt : float
+        Sampling interval in seconds.
+    sigma : float or None
+        Gaussian sigma in seconds. Required for method="gaussian" unless
+        window is provided (sigma defaults to window/6).
+    window : float or None
+        Total window width in seconds. Required for method="boxcar".
+        For Gaussian, defaults to 6*sigma.
+
+    Returns
+    -------
+    ndarray, shape (kernel_size,)
+        Normalized kernel that sums to 1.
+    """
+    method = method.lower()
+    if method == "gaussian":
+        if sigma is None and window is None:
+            raise ValueError("gaussian smoothing requires sigma or window.")
+        if sigma is None:
+            sigma = float(window) / 6.0
+        if window is None:
+            window = 6.0 * float(sigma)
+        sigma_bins = float(sigma) / dt
+        if sigma_bins <= 0:
+            return np.asarray([1.0])
+        half = int(np.ceil(0.5 * float(window) / dt))
+        size = max(1, 2 * half + 1)
+        x = np.arange(size, dtype=float) - size // 2
+        kernel = np.exp(-0.5 * (x / sigma_bins) ** 2)
+        kernel /= kernel.sum()
+        return kernel
+
+    if method in ("boxcar", "mean", "moving"):
+        if window is None:
+            raise ValueError("boxcar smoothing requires window.")
+        size = int(np.ceil(float(window) / dt))
+        size = max(1, size)
+        kernel = np.ones(size, dtype=float)
+        kernel /= kernel.sum()
+        return kernel
+
+    raise ValueError(f"Unknown smoothing method {method!r}.")
+
+
+def convolve_1d(
+    y: NDArray[np.float64],
+    kernel: NDArray[np.float64],
+    *,
+    boundary: str = "reflect",
+    causal: bool = False,
+) -> NDArray[np.float64]:
+    """Convolve a 1-D signal with a kernel, handling boundaries.
+
+    Parameters
+    ----------
+    y : ndarray, shape (n,)
+        Input signal.
+    kernel : ndarray, shape (k,)
+        Convolution kernel (should sum to 1 for smoothing).
+    boundary : str
+        Padding mode: "reflect", "nearest"/"edge", or "constant".
+    causal : bool
+        If True, use causal (left-sided) convolution with edge
+        normalization.
+
+    Returns
+    -------
+    ndarray, shape (n,)
+        Smoothed signal.
+    """
+    if kernel.size == 1:
+        return y.copy()
+    if causal:
+        out = np.convolve(y, kernel, mode="full")
+        # Normalize by the effective kernel mass at each sample so the
+        # leading edge uses an average over available history instead of
+        # zero-padding.
+        norm = np.convolve(np.ones(y.shape[0], dtype=float), kernel, mode="full")
+        out = out[: y.shape[0]]
+        norm = norm[: y.shape[0]]
+        return out / np.maximum(norm, np.finfo(float).eps)
+    boundary = boundary.lower()
+    pad = kernel.size // 2
+    if pad == 0:
+        return y.copy()
+    if boundary == "reflect":
+        y_pad = np.pad(y, pad_width=pad, mode="reflect")
+    elif boundary in ("nearest", "edge"):
+        y_pad = np.pad(y, pad_width=pad, mode="edge")
+    elif boundary == "constant":
+        y_pad = np.pad(y, pad_width=pad, mode="constant")
+    else:
+        raise ValueError(f"Unknown boundary mode {boundary!r}.")
+    return np.convolve(y_pad, kernel, mode="valid")
+
+
+def smooth(
+    data: NDArray[np.float64],
+    dt: float,
+    *,
+    method: str = "gaussian",
+    sigma: float | None = None,
+    window: float | None = None,
+    boundary: str = "reflect",
+) -> NDArray[np.float64]:
+    """Smooth dense data along the last axis (time).
+
+    Accepts arrays of any dimensionality; smoothing is applied
+    independently along the last axis. For the standard
+    (trial, unit, time) layout, this means smoothing along time.
+
+    Parameters
+    ----------
+    data : ndarray, shape (..., n_time)
+        Dense data array. Last axis is time.
+    dt : float
+        Sampling interval in seconds.
+    method : str
+        "gaussian" or "boxcar".
+    sigma : float or None
+        Gaussian sigma in seconds.
+    window : float or None
+        Window width in seconds (boxcar) or total Gaussian window.
+    boundary : str
+        Boundary mode for non-causal smoothing.
+
+    Returns
+    -------
+    ndarray, same shape as data
+        Smoothed data.
+    """
+    if sigma is not None:
+        method = "gaussian"
+    elif method.lower() == "gaussian" and sigma is None and window is None:
+        raise ValueError("Gaussian smoothing requires sigma parameter.")
+
+    kernel = make_kernel(method, dt, sigma=sigma, window=window)
+    # Boxcar uses causal (left-sided) convolution with edge normalization
+    # so the moving average only looks backward in time. Gaussian uses
+    # symmetric boundary padding so the kernel is centered on each sample.
+    causal = method.lower() in ("boxcar", "mean", "moving")
+
+    if kernel.size == 1:
+        return data.copy()
+
+    # Reshape to 2D: (batch, n_time), apply, reshape back.
+    orig_shape = data.shape
+    n_time = orig_shape[-1]
+    flat = data.reshape(-1, n_time)
+    out = np.empty_like(flat)
+    for i in range(flat.shape[0]):
+        out[i] = convolve_1d(flat[i], kernel, boundary=boundary, causal=causal)
+    return out.reshape(orig_shape)

--- a/src/aind_ephys_utils/types.py
+++ b/src/aind_ephys_utils/types.py
@@ -1,0 +1,242 @@
+"""Typed containers for electrophysiology data.
+
+Two primary types:
+
+- :class:`RaggedSpikes` -- variable-length spike trains per trial/unit
+- :class:`BinnedSpikes` -- dense ``(trial, unit, time)`` arrays
+
+Both carry metadata dicts and support constructors from raw arrays and
+interop with xarray via ``.to_xarray()`` / ``.from_xarray()``.
+
+For operations on these types, use :mod:`aind_ephys_utils.core` (pure
+numpy) or :mod:`aind_ephys_utils.xarray` (DataArray in/out with
+``.pipe()`` chaining).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+from . import core
+
+
+# ------------------------------------------------------------------
+# RaggedSpikes
+# ------------------------------------------------------------------
+
+
+@dataclass
+class RaggedSpikes:
+    """Variable-length spike times organized by trial and unit.
+
+    Attributes
+    ----------
+    spike_times : list of list of ndarray
+        ``spike_times[trial][unit]`` is a sorted 1-D float64 array of
+        spike times (in seconds, relative to trial anchor or session).
+    n_trials : int
+        Number of trials.
+    n_units : int
+        Number of units.
+    time_window : tuple of float or None
+        ``(tmin, tmax)`` valid interval, if known.
+    trial_meta : dict of {str: ndarray}
+        Per-trial metadata. Each value has shape ``(n_trials,)``.
+    unit_meta : dict of {str: ndarray}
+        Per-unit metadata. Each value has shape ``(n_units,)``.
+    """
+
+    spike_times: list[list[NDArray[np.float64]]]
+    n_trials: int
+    n_units: int
+    time_window: tuple[float, float] | None = None
+    trial_meta: dict[str, NDArray] = field(default_factory=dict)
+    unit_meta: dict[str, NDArray] = field(default_factory=dict)
+
+    # ---- constructors ----
+
+    @classmethod
+    def from_arrays(
+        cls,
+        spike_times: (list[NDArray[np.float64]] | dict[object, NDArray[np.float64]]),
+        anchor_times: NDArray[np.float64] | None = None,
+        window: tuple[float, float] | None = None,
+        *,
+        unit_ids: Sequence | None = None,
+        trial_meta: dict[str, NDArray] | None = None,
+        unit_meta: dict[str, NDArray] | None = None,
+    ) -> RaggedSpikes:
+        """Construct from per-unit spike time arrays.
+
+        Parameters
+        ----------
+        spike_times : list of ndarray, or dict
+            Per-unit spike times. If list, ``spike_times[u]`` is a 1-D
+            sorted array of spike times for unit *u* (session time).
+            If dict, keys are unit IDs and values are 1-D arrays.
+        anchor_times : ndarray, shape (n_trials,), optional
+            If provided, spikes are aligned to these anchors with the
+            given *window*, producing trial-segmented ragged data. If
+            ``None``, all spikes are placed in a single "trial".
+        window : (float, float), optional
+            Required when *anchor_times* is provided.
+        unit_ids : sequence, optional
+            Unit identifiers. Defaults to ``range(n_units)``.
+        trial_meta : dict, optional
+            Per-trial metadata arrays.
+        unit_meta : dict, optional
+            Per-unit metadata arrays.
+        """
+        # Normalize spike_times to list form.
+        if isinstance(spike_times, dict):
+            if unit_ids is None:
+                unit_ids = list(spike_times.keys())
+            spike_list = [spike_times[k] for k in unit_ids]
+        else:
+            spike_list = list(spike_times)
+
+        n_units = len(spike_list)
+        if unit_ids is None:
+            unit_ids = list(range(n_units))
+
+        umeta = {"unit_id": np.asarray(unit_ids)}
+        if unit_meta:
+            umeta.update(unit_meta)
+
+        if anchor_times is not None:
+            if window is None:
+                raise ValueError("window is required when anchor_times is provided.")
+            aligned = core.align(spike_list, np.asarray(anchor_times), window)
+            return cls(
+                spike_times=aligned,
+                n_trials=len(anchor_times),
+                n_units=n_units,
+                time_window=window,
+                trial_meta=trial_meta or {},
+                unit_meta=umeta,
+            )
+
+        # Single "trial" containing all spikes.
+        single_trial = [np.asarray(s, dtype=np.float64) for s in spike_list]
+        return cls(
+            spike_times=[single_trial],
+            n_trials=1,
+            n_units=n_units,
+            time_window=None,
+            trial_meta=trial_meta or {},
+            unit_meta=umeta,
+        )
+
+    # ---- interop ----
+
+    def to_xarray(self):
+        """Convert to ``xr.DataArray`` with object dtype."""
+        from .adapters.xarray import ragged_to_xarray
+
+        return ragged_to_xarray(self)
+
+    @classmethod
+    def from_xarray(cls, da) -> RaggedSpikes:
+        """Construct from an ``xr.DataArray`` with object dtype."""
+        from .adapters.xarray import xarray_to_ragged
+
+        return xarray_to_ragged(da)
+
+
+# ------------------------------------------------------------------
+# BinnedSpikes
+# ------------------------------------------------------------------
+
+
+@dataclass
+class BinnedSpikes:
+    """Dense binned spike data with fixed ``(trial, unit, time)`` layout.
+
+    Attributes
+    ----------
+    data : ndarray, shape (n_trials, n_units, n_time)
+        Spike counts or rates.
+    time : ndarray, shape (n_time,)
+        Bin center times.
+    trial_meta : dict of {str: ndarray}
+        Per-trial metadata. Each value has shape ``(n_trials,)``.
+    unit_meta : dict of {str: ndarray}
+        Per-unit metadata. Each value has shape ``(n_units,)``.
+    """
+
+    data: NDArray[np.float64]
+    time: NDArray[np.float64]
+    trial_meta: dict[str, NDArray] = field(default_factory=dict)
+    unit_meta: dict[str, NDArray] = field(default_factory=dict)
+
+    @property
+    def n_trials(self) -> int:
+        return self.data.shape[0]
+
+    @property
+    def n_units(self) -> int:
+        return self.data.shape[1]
+
+    @property
+    def n_time(self) -> int:
+        return self.data.shape[2]
+
+    # ---- constructors ----
+
+    @classmethod
+    def from_arrays(
+        cls,
+        data: NDArray[np.float64],
+        time: NDArray[np.float64],
+        *,
+        axes: tuple[str, ...] | None = None,
+        trial_meta: dict[str, NDArray] | None = None,
+        unit_meta: dict[str, NDArray] | None = None,
+    ) -> BinnedSpikes:
+        """Construct from arrays with optional axis transposition.
+
+        Parameters
+        ----------
+        data : ndarray
+            Dense spike data.
+        time : ndarray, shape (n_time,)
+            Time bin centers.
+        axes : tuple of str, optional
+            Current axis names, e.g. ``("unit", "trial", "time")``.
+            Data will be transposed to canonical
+            ``(trial, unit, time)``. If ``None``, assumes already in
+            canonical order.
+        trial_meta, unit_meta : dict, optional
+            Metadata arrays.
+        """
+        if axes is not None:
+            canonical = ("trial", "unit", "time")
+            if sorted(axes) != sorted(canonical):
+                raise ValueError(f"axes must contain exactly {canonical}, got {axes}.")
+            perm = tuple(axes.index(c) for c in canonical)
+            data = np.transpose(data, perm)
+        return cls(
+            data=np.asarray(data, dtype=np.float64),
+            time=np.asarray(time, dtype=np.float64),
+            trial_meta=trial_meta or {},
+            unit_meta=unit_meta or {},
+        )
+
+    # ---- interop ----
+
+    def to_xarray(self):
+        """Convert to ``xr.DataArray`` with named dimensions."""
+        from .adapters.xarray import binned_to_xarray
+
+        return binned_to_xarray(self)
+
+    @classmethod
+    def from_xarray(cls, da) -> BinnedSpikes:
+        """Construct from an ``xr.DataArray``."""
+        from .adapters.xarray import xarray_to_binned
+
+        return xarray_to_binned(da)

--- a/src/aind_ephys_utils/xarray.py
+++ b/src/aind_ephys_utils/xarray.py
@@ -1,0 +1,601 @@
+"""xarray-native wrappers for core operations.
+
+DataArray in, DataArray out. Each function uses xarray's own operations
+(broadcasting, ``.sel()``, ``.mean()``, ``apply_ufunc``) where possible,
+falling back to :mod:`~aind_ephys_utils.core` only for operations without
+xarray equivalents (binning, alignment, ragged restrict).
+
+Fluent chaining works via xarray's built-in ``.pipe()``::
+
+    from aind_ephys_utils.xarray import smooth, baseline, normalize, psth
+
+    result = (
+        da
+        .pipe(align, events=events, to="stimulus", window=(-0.5, 1.0))
+        .pipe(bin, dt=0.05)
+        .pipe(smooth, sigma=0.03)
+        .pipe(baseline, window=(-0.5, 0.0))
+        .pipe(psth, labels=conditions)
+    )
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from numpy.typing import NDArray
+
+from . import core
+from .standards.conventions import C
+
+__all__ = [
+    "align",
+    "baseline",
+    "bin",
+    "normalize",
+    "psth",
+    "restrict",
+    "smooth",
+]
+
+
+# ------------------------------------------------------------------
+# Internal helpers -- coord preservation and event handling
+# ------------------------------------------------------------------
+
+
+def _preserve_coords(src: xr.DataArray, out: xr.DataArray) -> xr.DataArray:
+    """Carry over non-indexed coords whose dims are a subset of output dims.
+
+    xarray drops non-indexed coordinates on arithmetic (e.g. ``da - mean``).
+    This restores them after such operations.
+    """
+    for name, coord in src.coords.items():
+        if name in out.coords:
+            continue
+        if set(coord.dims).issubset(set(out.dims)):
+            out = out.assign_coords({name: coord})
+    return out
+
+
+def _normalize_events(events: xr.Dataset | xr.DataArray) -> xr.Dataset:
+    """Normalize events input to a Dataset with a ``"t"`` variable.
+
+    Accepts:
+    - Dataset with var ``"t"``, dims ``(trial, event)``
+    - DataArray of event times, dims ``(trial, event)``
+    - DataArray with dims ``(trial, event, bound)`` -- selects ``"start"``
+    """
+    if isinstance(events, xr.DataArray):
+        if "bound" in events.dims:
+            if "start" not in events.coords.get("bound", []):
+                raise ValueError(
+                    "events['bound'] must include 'start' when using "
+                    "(trial, event, bound) representation."
+                )
+            events = events.sel(bound="start")
+        return xr.Dataset({C.event_time_var: events})
+    if isinstance(events, xr.Dataset):
+        if C.event_time_var not in events:
+            raise ValueError(f"events must contain variable {C.event_time_var!r}.")
+        return events
+    raise TypeError(
+        f"events must be an xarray Dataset or DataArray, got {type(events)!r}."
+    )
+
+
+def _get_event_times(events: xr.Dataset, to: str) -> xr.DataArray:
+    """Select per-trial event times for a specific event label.
+
+    Returns a DataArray with dims ``(trial,)``.
+    """
+    t = events[C.event_time_var]
+    if C.event not in t.dims:
+        raise ValueError(
+            f"events['{C.event_time_var}'] must have a '{C.event}' dimension. "
+            f"Got dims {t.dims}."
+        )
+    try:
+        return t.sel({C.event: to})
+    except KeyError as e:
+        raise ValueError(
+            f"Could not find event label {to!r} in events['{C.event_time_var}']."
+        ) from e
+
+
+# ------------------------------------------------------------------
+# Internal helpers -- ragged operations
+# ------------------------------------------------------------------
+
+
+def _unpack_ragged(
+    da: xr.DataArray,
+) -> tuple[list[list[NDArray]], int, int, xr.DataArray]:
+    """Extract ``list[list[ndarray]]`` from a ragged object DataArray.
+
+    Transposes to ``(trial, unit)`` order.  Returns
+    ``(spike_times, n_trials, n_units, da_transposed)``.
+    """
+    has_trial = C.trial in da.dims
+    has_unit = C.unit in da.dims
+
+    if has_trial and has_unit:
+        da_work = da.transpose(C.trial, C.unit)
+    elif has_trial:
+        da_work = da.expand_dims(C.unit, axis=-1)
+    elif has_unit:
+        da_work = da.expand_dims(C.trial, axis=0)
+    else:
+        raise ValueError(
+            "Ragged DataArray must have at least a 'trial' or 'unit' dimension."
+        )
+
+    n_trials, n_units = da_work.shape
+    spike_times: list[list[NDArray]] = []
+    for t in range(n_trials):
+        trial_spikes: list[NDArray] = []
+        for u in range(n_units):
+            val = da_work.values[t, u]
+            if val is None:
+                trial_spikes.append(np.array([], dtype=np.float64))
+            else:
+                trial_spikes.append(np.asarray(val, dtype=np.float64))
+        spike_times.append(trial_spikes)
+    return spike_times, n_trials, n_units, da_work
+
+
+def _repack_ragged(
+    src_da: xr.DataArray,
+    spike_times: list[list[NDArray]],
+    n_trials: int,
+    n_units: int,
+    *,
+    trial_coord: NDArray | xr.DataArray | None = None,
+    unit_coord: NDArray | xr.DataArray | None = None,
+) -> xr.DataArray:
+    """Wrap ragged spike times back into an object-dtype DataArray."""
+    out_data = np.empty((n_trials, n_units), dtype=object)
+    for t in range(n_trials):
+        for u in range(n_units):
+            out_data[t, u] = spike_times[t][u]
+
+    coords: dict = {}
+    if trial_coord is not None:
+        coords[C.trial] = trial_coord
+    elif C.trial in src_da.coords:
+        coords[C.trial] = src_da.coords[C.trial]
+    if unit_coord is not None:
+        coords[C.unit] = unit_coord
+    elif C.unit in src_da.coords:
+        coords[C.unit] = src_da.coords[C.unit]
+
+    out = xr.DataArray(
+        out_data,
+        dims=(C.trial, C.unit),
+        coords=coords,
+        name=src_da.name,
+        attrs=dict(src_da.attrs),
+    )
+    return _preserve_coords(src_da, out)
+
+
+def _infer_tlim(da: xr.DataArray) -> tuple[float, float]:
+    """Infer ``(tmin, tmax)`` from ragged spike data."""
+    tmin = np.inf
+    tmax = -np.inf
+    for x in da.values.ravel():
+        if x is None:
+            continue
+        arr = np.asarray(x, dtype=float)
+        if arr.size == 0:
+            continue
+        tmin = min(tmin, float(arr.min()))
+        tmax = max(tmax, float(arr.max()))
+    if not np.isfinite(tmin) or not np.isfinite(tmax):
+        raise ValueError("Cannot infer time limits from empty spike arrays.")
+    if tmin == tmax:
+        tmax = tmin + 1e-6
+    return tmin, tmax
+
+
+# ------------------------------------------------------------------
+# Public wrappers -- xarray-native
+# ------------------------------------------------------------------
+
+
+def smooth(
+    da: xr.DataArray,
+    *,
+    sigma: float | None = None,
+    method: str = "gaussian",
+    window: float | None = None,
+    boundary: str = "reflect",
+    dim: str = C.time,
+) -> xr.DataArray:
+    """Smooth a DataArray along a dimension.
+
+    Uses ``xr.apply_ufunc`` to broadcast :func:`core.convolve_1d` over
+    all non-core dimensions, preserving coordinates automatically.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Dense DataArray.
+    sigma : float, optional
+        Gaussian kernel sigma in seconds.
+    method : str
+        ``"gaussian"`` or ``"boxcar"``.
+    window : float, optional
+        Boxcar window width in seconds.
+    boundary : str
+        Boundary padding mode for convolution.
+    dim : str
+        Dimension to smooth along (default ``"time"``).
+    """
+    if dim not in da.dims:
+        raise ValueError(f"dim {dim!r} not found in DataArray dims {da.dims}.")
+
+    time_vals = np.asarray(da.coords[dim].values, dtype=np.float64)
+    dt = core.infer_dt(time_vals)
+
+    if sigma is not None:
+        method = "gaussian"
+    elif method.lower() == "gaussian" and sigma is None and window is None:
+        raise ValueError("Gaussian smoothing requires sigma parameter.")
+
+    kernel = core.make_kernel(method, dt, sigma=sigma, window=window)
+    if kernel.size == 1:
+        return da.copy()
+
+    causal = method.lower() in ("boxcar", "mean", "moving")
+
+    out = xr.apply_ufunc(
+        core.convolve_1d,
+        da,
+        input_core_dims=[[dim]],
+        output_core_dims=[[dim]],
+        vectorize=True,
+        output_dtypes=[float],
+        kwargs={"kernel": kernel, "boundary": boundary, "causal": causal},
+    )
+    out.attrs = dict(da.attrs)
+    out = _preserve_coords(da, out)
+    return out.transpose(*da.dims)
+
+
+def baseline(
+    da: xr.DataArray,
+    *,
+    window: tuple[float, float],
+    dim: str = C.time,
+    mode: str = "subtract",
+) -> xr.DataArray:
+    """Apply baseline correction over a time window.
+
+    Uses xarray's ``.sel()`` and ``.mean()`` for dimension handling --
+    no manual transposition or repacking needed.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Dense DataArray.
+    window : (float, float)
+        ``(tmin, tmax)`` baseline window.
+    dim : str
+        Time dimension name.
+    mode : str
+        ``"subtract"``, ``"divide"``, or ``"zscore"``.
+    """
+    if dim not in da.dims:
+        raise ValueError(f"dim {dim!r} not found in DataArray dims {da.dims}.")
+
+    tmin, tmax = window
+    bl = da.sel({dim: slice(tmin, tmax)})
+    if bl.sizes[dim] == 0:
+        raise ValueError("Baseline window produced no samples.")
+
+    mean = bl.mean(dim=dim)
+
+    mode = mode.lower()
+    if mode == "subtract":
+        out = da - mean
+    elif mode == "divide":
+        out = da / mean
+    elif mode == "zscore":
+        std = bl.std(dim=dim)
+        safe_std = std.where(std != 0, 1.0)
+        out = (da - mean) / safe_std
+        out = out.where(std != 0, 0.0)
+    else:
+        raise ValueError(f"Unknown baseline mode {mode!r}.")
+
+    out.attrs = dict(da.attrs)
+    return _preserve_coords(da, out)
+
+
+def normalize(
+    da: xr.DataArray,
+    *,
+    dim: str | tuple[str, ...],
+    method: str = "zscore",
+) -> xr.DataArray:
+    """Normalize across one or more dimensions.
+
+    Uses xarray's broadcasting so no canonical dim ordering is required.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Dense DataArray.
+    dim : str or tuple of str
+        Dimension(s) to normalize across.
+    method : str
+        ``"zscore"``, ``"minmax"``, or ``"robust"``.
+    """
+    if isinstance(dim, str):
+        dims = (dim,)
+    else:
+        dims = tuple(dim)
+
+    for d in dims:
+        if d not in da.dims:
+            raise ValueError(f"dim {d!r} not found in DataArray dims {da.dims}.")
+
+    dims_list = list(dims)
+    method = method.lower()
+
+    if method == "zscore":
+        mean = da.mean(dim=dims_list)
+        std = da.std(dim=dims_list)
+        safe_std = std.where(std != 0, 1.0)
+        out = (da - mean) / safe_std
+        out = out.where(std != 0, 0.0)
+    elif method == "minmax":
+        vmin = da.min(dim=dims_list)
+        vmax = da.max(dim=dims_list)
+        denom = vmax - vmin
+        safe_denom = denom.where(denom != 0, 1.0)
+        out = (da - vmin) / safe_denom
+        out = out.where(denom != 0, 0.0)
+    elif method == "robust":
+        q25 = da.quantile(0.25, dim=dims_list).drop_vars("quantile")
+        q75 = da.quantile(0.75, dim=dims_list).drop_vars("quantile")
+        median = da.quantile(0.5, dim=dims_list).drop_vars("quantile")
+        iqr = q75 - q25
+        safe_iqr = iqr.where(iqr != 0, 1.0)
+        out = (da - median) / safe_iqr
+        out = out.where(iqr != 0, 0.0)
+    else:
+        raise ValueError(f"Unknown normalization method {method!r}.")
+
+    out.attrs = dict(da.attrs)
+    return _preserve_coords(da, out)
+
+
+def psth(
+    da: xr.DataArray,
+    *,
+    method: str = "mean",
+    labels: NDArray | None = None,
+    dim: str = C.trial,
+) -> xr.DataArray:
+    """Compute trial-averaged PSTH.
+
+    Uses xarray's ``.mean()`` / ``.median()`` for unlabeled reduction,
+    and ``xr.concat`` with per-group reduction for labeled PSTH.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Dense DataArray.
+    method : str
+        ``"mean"`` or ``"median"``.
+    labels : ndarray, optional
+        Per-trial group labels. If provided, the reduced dimension is
+        replaced by a group dimension with one entry per unique label.
+    dim : str
+        Dimension to reduce (default ``"trial"``).
+    """
+    if dim not in da.dims:
+        raise ValueError(f"dim {dim!r} not found in DataArray dims {da.dims}.")
+
+    method = method.lower()
+    if method not in ("mean", "median"):
+        raise ValueError(f"Unknown PSTH method {method!r}.")
+
+    reduce_fn = method  # "mean" or "median" -- used as method name on DataArray
+
+    if labels is None:
+        out = getattr(da, reduce_fn)(dim=dim)
+        out.attrs = dict(da.attrs)
+        return _preserve_coords(da, out)
+
+    # Grouped PSTH: reduce within each label group, then concat.
+    labels = np.asarray(labels)
+    unique = np.unique(labels)
+    parts = []
+    for lbl in unique:
+        mask = labels == lbl
+        subset = da.isel({dim: mask})
+        parts.append(getattr(subset, reduce_fn)(dim=dim))
+
+    out = xr.concat(parts, dim=dim)
+    out[dim] = unique
+    out.attrs = dict(da.attrs)
+    return _preserve_coords(da, out)
+
+
+def restrict(
+    da: xr.DataArray,
+    window: tuple[float, float],
+    *,
+    dim: str = C.time,
+) -> xr.DataArray:
+    """Restrict a DataArray to a time window.
+
+    Dispatches between dense and ragged based on dtype.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Dense or ragged DataArray.
+    window : (float, float)
+        ``(tmin, tmax)`` time window.
+    dim : str
+        Time dimension for dense data.
+    """
+    if da.dtype == object:
+        return _restrict_ragged(da, window)
+    return _restrict_dense(da, window, dim=dim)
+
+
+def _restrict_dense(
+    da: xr.DataArray,
+    window: tuple[float, float],
+    *,
+    dim: str = C.time,
+) -> xr.DataArray:
+    if dim not in da.dims:
+        raise ValueError(f"dim {dim!r} not found in DataArray dims {da.dims}.")
+    tmin, tmax = window
+    if tmin > tmax:
+        raise ValueError(f"window must have tmin <= tmax, got {window}.")
+    return da.sel({dim: slice(tmin, tmax)})
+
+
+def _restrict_ragged(
+    da: xr.DataArray,
+    window: tuple[float, float],
+) -> xr.DataArray:
+    spike_times, n_trials, n_units, _ = _unpack_ragged(da)
+    restricted = core.restrict_ragged(spike_times, window)
+    out = _repack_ragged(da, restricted, n_trials, n_units)
+    out.attrs[C.attr_valid_intervals] = [window]
+    return out
+
+
+# ------------------------------------------------------------------
+# Public wrappers -- core-backed (no xarray equivalent)
+# ------------------------------------------------------------------
+
+
+def bin(
+    da: xr.DataArray,
+    dt: float,
+    *,
+    window: tuple[float, float] | None = None,
+    output: str = "rate",
+) -> xr.DataArray:
+    """Bin ragged spikes into a dense representation.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Ragged spike DataArray (``dtype=object``).
+    dt : float
+        Bin width in seconds.
+    window : (float, float), optional
+        Time window. If ``None``, inferred from attrs or data.
+    output : str
+        ``"rate"`` (spikes/s) or ``"count"``.
+    """
+    if da.dtype != object:
+        raise ValueError("bin expects ragged spikes with dtype=object.")
+
+    has_trial = C.trial in da.dims
+    has_unit = C.unit in da.dims
+    if not has_trial and not has_unit:
+        raise ValueError("bin requires at least a 'trial' or 'unit' dimension.")
+
+    if window is None:
+        intervals = da.attrs.get(C.attr_valid_intervals)
+        if intervals:
+            window = tuple(intervals[0])
+        else:
+            window = _infer_tlim(da)
+
+    spike_times, n_trials, n_units, da_work = _unpack_ragged(da)
+    data, centers = core.bin_spikes(spike_times, dt, window, output=output)
+
+    # Build output dims and coords based on which dims were in the input.
+    if has_trial and has_unit:
+        out_data = data
+        out_dims = (C.trial, C.unit, C.time)
+        coords: dict = {
+            C.trial: da_work.coords.get(C.trial, np.arange(n_trials)),
+            C.unit: da_work.coords.get(C.unit, np.arange(n_units)),
+            C.time: centers,
+        }
+    elif has_unit:
+        out_data = data[0]  # squeeze synthetic trial dim
+        out_dims = (C.unit, C.time)
+        coords = {
+            C.unit: da.coords.get(C.unit, np.arange(n_units)),
+            C.time: centers,
+        }
+    else:  # has_trial only
+        out_data = data[:, 0, :]  # squeeze synthetic unit dim
+        out_dims = (C.trial, C.time)
+        coords = {
+            C.trial: da.coords.get(C.trial, np.arange(n_trials)),
+            C.time: centers,
+        }
+
+    out = xr.DataArray(
+        out_data,
+        dims=out_dims,
+        coords=coords,
+        name=da.name,
+        attrs=dict(da.attrs),
+    )
+    out = _preserve_coords(da, out)
+    out.attrs[C.attr_valid_intervals] = [window]
+    return out
+
+
+def align(
+    da: xr.DataArray,
+    *,
+    events: xr.Dataset | xr.DataArray,
+    to: str,
+    window: tuple[float, float],
+) -> xr.DataArray:
+    """Align ragged spikes to event times.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Ragged spike DataArray (``dtype=object``). Expects a single
+        "trial" containing all session spikes per unit, i.e. shape
+        ``(1, n_units)`` or ``(n_units,)``.
+    events : xr.Dataset or xr.DataArray
+        Event times with a ``"trial"`` and ``"event"`` dimension.
+    to : str
+        Event label to align to.
+    window : (float, float)
+        ``(tmin, tmax)`` relative to event time.
+    """
+    tmin, tmax = window
+    if tmin >= tmax:
+        raise ValueError(f"window must be (tmin, tmax) with tmin < tmax, got {window}.")
+
+    events_ds = _normalize_events(events)
+    t0 = _get_event_times(events_ds, to=to)
+    anchor_times = t0.values.astype(np.float64)
+
+    # Unpack the single-session ragged array and extract per-unit spike lists.
+    ragged, _, n_units, _ = _unpack_ragged(da)
+    spike_list = ragged[0]  # first (and only) "trial" = all session spikes
+
+    aligned = core.align(spike_list, anchor_times, window)
+    n_trials = len(anchor_times)
+
+    out = _repack_ragged(
+        da,
+        aligned,
+        n_trials,
+        n_units,
+        trial_coord=t0[C.trial] if C.trial in t0.coords else np.arange(n_trials),
+    )
+    out.attrs[C.attr_valid_intervals] = [window]
+    return out

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,378 @@
+"""Tests for the pure-numpy core module.
+
+No xarray is imported anywhere in this file. This is by design: it
+verifies that the core operates independently of xarray.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+
+from aind_ephys_utils.core import (
+    align,
+    align_unit,
+    baseline,
+    bin_spikes,
+    convolve_1d,
+    infer_dt,
+    make_bin_edges,
+    make_kernel,
+    normalize,
+    psth,
+    restrict_dense,
+    restrict_ragged,
+    smooth,
+)
+
+
+# ---- smooth ----
+
+
+class InferDtTest(unittest.TestCase):
+    def test_uniform(self):
+        t = np.array([0.0, 0.1, 0.2, 0.3])
+        assert_allclose(infer_dt(t), 0.1)
+
+    def test_non_uniform_raises(self):
+        t = np.array([0.0, 0.1, 0.3])
+        with self.assertRaises(ValueError):
+            infer_dt(t)
+
+    def test_too_few_raises(self):
+        with self.assertRaises(ValueError):
+            infer_dt(np.array([1.0]))
+
+    def test_decreasing_raises(self):
+        with self.assertRaises(ValueError):
+            infer_dt(np.array([1.0, 0.0]))
+
+
+class MakeKernelTest(unittest.TestCase):
+    def test_gaussian_sums_to_one(self):
+        k = make_kernel("gaussian", 0.01, sigma=0.05)
+        assert_allclose(k.sum(), 1.0, atol=1e-10)
+
+    def test_boxcar_sums_to_one(self):
+        k = make_kernel("boxcar", 0.01, window=0.05)
+        assert_allclose(k.sum(), 1.0, atol=1e-10)
+
+    def test_boxcar_size(self):
+        k = make_kernel("boxcar", 0.01, window=0.05)
+        self.assertEqual(len(k), 5)
+
+    def test_unknown_method_raises(self):
+        with self.assertRaises(ValueError):
+            make_kernel("hamming", 0.01)
+
+
+class Convolve1dTest(unittest.TestCase):
+    def test_identity_kernel(self):
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        out = convolve_1d(y, np.array([1.0]))
+        assert_array_equal(out, y)
+
+    def test_gaussian_preserves_total(self):
+        y = np.zeros(100)
+        y[50] = 1.0
+        k = make_kernel("gaussian", 0.01, sigma=0.03)
+        out = convolve_1d(y, k)
+        assert_allclose(out.sum(), y.sum(), atol=0.05)
+
+    def test_causal_leading_edge(self):
+        """First sample should equal itself (no attenuation)."""
+        y = np.ones(20)
+        k = make_kernel("boxcar", 0.01, window=0.05)
+        out = convolve_1d(y, k, causal=True)
+        assert_allclose(out[0], 1.0, atol=1e-10)
+
+
+class SmoothTest(unittest.TestCase):
+    def test_3d_shape_preserved(self):
+        data = np.random.default_rng(0).standard_normal((3, 2, 50))
+        dt = 0.01
+        out = smooth(data, dt, sigma=0.03)
+        self.assertEqual(out.shape, data.shape)
+
+    def test_1d(self):
+        data = np.zeros(100)
+        data[50] = 1.0
+        out = smooth(data, 0.01, sigma=0.03)
+        assert_allclose(out.sum(), 1.0, atol=0.05)
+
+    def test_gaussian_requires_sigma(self):
+        with self.assertRaises(ValueError):
+            smooth(np.zeros(10), 0.01, method="gaussian")
+
+
+# ---- align ----
+
+
+class AlignUnitTest(unittest.TestCase):
+    def test_basic(self):
+        # 10 spikes at 0.0, 1.0, ..., 9.0
+        spikes = np.arange(10, dtype=float)
+        anchors = np.array([2.0, 5.0])
+        result = align_unit(spikes, anchors, (-0.5, 0.5))
+        # Trial 0 centered at 2.0: spike at 2.0 → 0.0
+        assert_allclose(result[0], [0.0])
+        # Trial 1 centered at 5.0: spike at 5.0 → 0.0
+        assert_allclose(result[1], [0.0])
+
+    def test_empty_window(self):
+        spikes = np.array([1.0, 2.0, 3.0])
+        anchors = np.array([10.0])
+        result = align_unit(spikes, anchors, (-0.1, 0.1))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].size, 0)
+
+    def test_none_input(self):
+        result = align_unit(None, np.array([1.0, 2.0]), (-0.5, 0.5))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].size, 0)
+        self.assertEqual(result[1].size, 0)
+
+
+class AlignTest(unittest.TestCase):
+    def test_multi_unit(self):
+        spike_times = [
+            np.array([0.5, 1.5, 2.5]),  # unit 0
+            np.array([0.3, 1.3, 2.3]),  # unit 1
+        ]
+        anchors = np.array([1.0, 2.0])
+        result = align(spike_times, anchors, (-0.6, 0.6))
+        # result[trial][unit]
+        self.assertEqual(len(result), 2)  # 2 trials
+        self.assertEqual(len(result[0]), 2)  # 2 units
+        # Trial 0, unit 0: spikes at 0.5 and 1.5 within [0.4, 1.6]
+        assert_allclose(result[0][0], [-0.5, 0.5])
+        # Trial 0, unit 1: spike at 1.3 within [0.4, 1.6] → 0.3
+        # (0.3 is below 0.4, so excluded)
+        assert_allclose(result[0][1], [0.3])
+
+    def test_invalid_window_raises(self):
+        with self.assertRaises(ValueError):
+            align([np.array([1.0])], np.array([0.0]), (1.0, -1.0))
+
+
+# ---- bin ----
+
+
+class MakeBinEdgesTest(unittest.TestCase):
+    def test_basic(self):
+        edges, centers = make_bin_edges(0.1, (0.0, 0.5))
+        assert_allclose(edges, [0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        assert_allclose(centers, [0.05, 0.15, 0.25, 0.35, 0.45])
+
+    def test_invalid_dt(self):
+        with self.assertRaises(ValueError):
+            make_bin_edges(-0.1, (0.0, 1.0))
+
+
+class BinSpikesTest(unittest.TestCase):
+    def test_count(self):
+        # 1 trial, 1 unit, spikes at 0.05 and 0.15
+        spikes = [[np.array([0.05, 0.15])]]
+        data, centers = bin_spikes(spikes, 0.1, (0.0, 0.3), output="count")
+        self.assertEqual(data.shape, (1, 1, 3))
+        assert_allclose(data[0, 0], [1.0, 1.0, 0.0])
+
+    def test_rate(self):
+        spikes = [[np.array([0.05, 0.15])]]
+        data, centers = bin_spikes(spikes, 0.1, (0.0, 0.3), output="rate")
+        assert_allclose(data[0, 0], [10.0, 10.0, 0.0])
+
+    def test_empty_trial(self):
+        spikes = [[np.array([])]]
+        data, centers = bin_spikes(spikes, 0.1, (0.0, 0.3), output="count")
+        assert_allclose(data[0, 0], [0.0, 0.0, 0.0])
+
+    def test_invalid_dt_raises(self):
+        with self.assertRaises(ValueError):
+            bin_spikes([[np.array([])]], 0.0, (0.0, 1.0))
+
+
+# ---- restrict ----
+
+
+class RestrictDenseTest(unittest.TestCase):
+    def test_basic(self):
+        data = np.arange(10, dtype=float).reshape(1, 1, 10)
+        time = np.arange(10, dtype=float)
+        rd, rt = restrict_dense(data, time, (2.0, 5.0))
+        self.assertEqual(rd.shape, (1, 1, 4))
+        assert_array_equal(rt, [2.0, 3.0, 4.0, 5.0])
+        assert_array_equal(rd[0, 0], [2.0, 3.0, 4.0, 5.0])
+
+
+class RestrictRaggedTest(unittest.TestCase):
+    def test_basic(self):
+        spikes = [[np.array([0.1, 0.5, 0.9, 1.5])]]
+        out = restrict_ragged(spikes, (0.2, 1.0))
+        assert_allclose(out[0][0], [0.5, 0.9])
+
+    def test_invalid_window(self):
+        with self.assertRaises(ValueError):
+            restrict_ragged([[np.array([])]], (1.0, 0.0))
+
+
+# ---- baseline ----
+
+
+class BaselineTest(unittest.TestCase):
+    def test_subtract(self):
+        # (1 trial, 1 unit, 4 time)
+        data = np.array([[[1.0, 2.0, 3.0, 4.0]]])
+        time = np.array([0.0, 1.0, 2.0, 3.0])
+        out = baseline(data, time, (0.0, 1.0), mode="subtract")
+        # baseline mean of [1, 2] = 1.5
+        assert_allclose(out[0, 0], [-0.5, 0.5, 1.5, 2.5])
+
+    def test_divide(self):
+        data = np.array([[[2.0, 4.0, 6.0, 8.0]]])
+        time = np.array([0.0, 1.0, 2.0, 3.0])
+        out = baseline(data, time, (0.0, 1.0), mode="divide")
+        assert_allclose(out[0, 0], [2.0 / 3.0, 4.0 / 3.0, 2.0, 8.0 / 3.0])
+
+    def test_zscore(self):
+        data = np.array([[[1.0, 3.0, 5.0, 7.0]]])
+        time = np.array([0.0, 1.0, 2.0, 3.0])
+        out = baseline(data, time, (0.0, 1.0), mode="zscore")
+        bl = np.array([1.0, 3.0])
+        mean, std = bl.mean(), bl.std()
+        assert_allclose(out[0, 0, 2], (5.0 - mean) / std)
+
+    def test_zscore_zero_std(self):
+        """Constant baseline should produce 0, not NaN."""
+        data = np.array([[[5.0, 5.0, 10.0, 15.0]]])
+        time = np.array([0.0, 1.0, 2.0, 3.0])
+        out = baseline(data, time, (0.0, 1.0), mode="zscore")
+        self.assertFalse(np.any(np.isnan(out)))
+        assert_allclose(out[0, 0, :2], [0.0, 0.0])
+
+    def test_empty_window_raises(self):
+        data = np.array([[[1.0, 2.0]]])
+        time = np.array([0.0, 1.0])
+        with self.assertRaises(ValueError):
+            baseline(data, time, (5.0, 6.0))
+
+
+# ---- normalize ----
+
+
+class NormalizeTest(unittest.TestCase):
+    def test_zscore_across_trials(self):
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal((10, 3, 20))
+        out = normalize(data, across="trials", method="zscore")
+        # Mean across trials should be ~0
+        assert_allclose(out.mean(axis=0), 0.0, atol=1e-10)
+
+    def test_zscore_zero_variance(self):
+        data = np.ones((5, 2, 10))
+        out = normalize(data, across="trials", method="zscore")
+        self.assertFalse(np.any(np.isnan(out)))
+        assert_allclose(out, 0.0)
+
+    def test_minmax_range(self):
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal((10, 3, 20))
+        out = normalize(data, across="trials", method="minmax")
+        # Along trial axis, each (unit,time) should be in [0,1]
+        self.assertGreaterEqual(out.min(), -1e-10)
+        self.assertLessEqual(out.max(), 1.0 + 1e-10)
+
+    def test_robust(self):
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal((10, 3, 20))
+        out = normalize(data, across="trials", method="robust")
+        self.assertEqual(out.shape, data.shape)
+
+    def test_multi_axis(self):
+        data = np.ones((5, 3, 10)) * 3.0
+        out = normalize(data, across=("trials", "time"), method="zscore")
+        assert_allclose(out, 0.0)
+
+    def test_unknown_axis_raises(self):
+        with self.assertRaises(ValueError):
+            normalize(np.zeros((5, 3, 10)), across="channels")
+
+
+# ---- psth ----
+
+
+class PsthTest(unittest.TestCase):
+    def test_mean_no_labels(self):
+        data = np.array([
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ])  # (2 trials, 2 units, 2 time)
+        out = psth(data, method="mean")
+        assert_allclose(out, [[3.0, 4.0], [5.0, 6.0]])
+
+    def test_median_no_labels(self):
+        data = np.array([
+            [[1.0, 2.0]],
+            [[3.0, 4.0]],
+            [[5.0, 6.0]],
+        ])  # (3, 1, 2)
+        out = psth(data, method="median")
+        assert_allclose(out, [[3.0, 4.0]])
+
+    def test_with_labels(self):
+        data = np.array([
+            [[1.0], [2.0]],
+            [[3.0], [4.0]],
+            [[5.0], [6.0]],
+            [[7.0], [8.0]],
+        ])  # (4 trials, 2 units, 1 time)
+        labels = np.array(["A", "B", "A", "B"])
+        result, unique = psth(data, labels=labels)
+        assert_array_equal(unique, ["A", "B"])
+        # Group A: trials 0 and 2 → mean
+        assert_allclose(result[0], [[(1 + 5) / 2], [(2 + 6) / 2]])
+        # Group B: trials 1 and 3 → mean
+        assert_allclose(result[1], [[(3 + 7) / 2], [(4 + 8) / 2]])
+
+    def test_unknown_method_raises(self):
+        with self.assertRaises(ValueError):
+            psth(np.zeros((2, 1, 5)), method="mode")
+
+
+# ---- import isolation ----
+
+
+class ImportIsolationTest(unittest.TestCase):
+    def test_no_xarray_in_core(self):
+        """Verify that core/ modules do not import xarray.
+
+        Note: the parent package ``aind_ephys_utils.__init__`` does
+        import xarray, so we can't check ``sys.modules`` naively.
+        Instead we inspect each core submodule's namespace.
+        """
+        import importlib
+        import types as stdlib_types
+
+        core_modules = [
+            "aind_ephys_utils.core.align",
+            "aind_ephys_utils.core.baseline",
+            "aind_ephys_utils.core.bin",
+            "aind_ephys_utils.core.normalize",
+            "aind_ephys_utils.core.psth",
+            "aind_ephys_utils.core.restrict",
+            "aind_ephys_utils.core.smooth",
+        ]
+        for modname in core_modules:
+            mod = importlib.import_module(modname)
+            for key, val in mod.__dict__.items():
+                if isinstance(val, stdlib_types.ModuleType):
+                    self.assertFalse(
+                        "xarray" in val.__name__,
+                        f"{modname} has xarray in its namespace: {key}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,82 @@
+"""Tests for the RaggedSpikes and BinnedSpikes dataclass types."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+
+from aind_ephys_utils.types import BinnedSpikes, RaggedSpikes
+
+
+# ---- RaggedSpikes ----
+
+
+class RaggedFromArraysTest(unittest.TestCase):
+    def test_with_alignment(self):
+        spike_times = [
+            np.array([0.5, 1.5, 2.5, 3.5]),  # unit 0
+            np.array([0.3, 1.3, 2.3, 3.3]),  # unit 1
+        ]
+        anchors = np.array([1.0, 2.0, 3.0])
+        rs = RaggedSpikes.from_arrays(spike_times, anchors, window=(-0.6, 0.6))
+        self.assertEqual(rs.n_trials, 3)
+        self.assertEqual(rs.n_units, 2)
+        self.assertEqual(rs.time_window, (-0.6, 0.6))
+        # Trial 0, unit 0: spikes at 0.5 within [0.4, 1.6] → -0.5, 0.5
+        assert_allclose(rs.spike_times[0][0], [-0.5, 0.5])
+
+    def test_no_alignment(self):
+        spike_times = [np.array([1.0, 2.0]), np.array([3.0])]
+        rs = RaggedSpikes.from_arrays(spike_times)
+        self.assertEqual(rs.n_trials, 1)
+        self.assertEqual(rs.n_units, 2)
+        self.assertIsNone(rs.time_window)
+
+    def test_from_dict(self):
+        spike_dict = {
+            "V1_01": np.array([0.1, 0.5]),
+            "M1_02": np.array([0.3, 0.7]),
+        }
+        rs = RaggedSpikes.from_arrays(spike_dict)
+        self.assertEqual(rs.n_units, 2)
+        assert_array_equal(rs.unit_meta["unit_id"], ["V1_01", "M1_02"])
+
+    def test_missing_window_raises(self):
+        with self.assertRaises(ValueError):
+            RaggedSpikes.from_arrays([np.array([1.0])], anchor_times=np.array([0.0]))
+
+
+# ---- BinnedSpikes ----
+
+
+class BinnedFromArraysTest(unittest.TestCase):
+    def test_canonical_order(self):
+        data = np.zeros((3, 2, 10))
+        time = np.linspace(0, 0.9, 10)
+        bs = BinnedSpikes.from_arrays(data, time)
+        self.assertEqual(bs.n_trials, 3)
+        self.assertEqual(bs.n_units, 2)
+        self.assertEqual(bs.n_time, 10)
+
+    def test_axes_transpose(self):
+        # Data in (unit, time, trial) order
+        data = np.arange(24, dtype=float).reshape(2, 4, 3)
+        time = np.array([0.0, 0.1, 0.2, 0.3])
+        bs = BinnedSpikes.from_arrays(data, time, axes=("unit", "time", "trial"))
+        # Should be transposed to (trial, unit, time) = (3, 2, 4)
+        self.assertEqual(bs.data.shape, (3, 2, 4))
+        assert_array_equal(bs.time, time)
+
+    def test_bad_axes_raises(self):
+        with self.assertRaises(ValueError):
+            BinnedSpikes.from_arrays(
+                np.zeros((3, 2, 10)),
+                np.zeros(10),
+                axes=("x", "y", "z"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xarray_adapter.py
+++ b/tests/test_xarray_adapter.py
@@ -1,0 +1,191 @@
+"""Tests for xarray <-> dataclass type round-trip conversions."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import xarray as xr
+from numpy.testing import assert_allclose, assert_array_equal
+
+from aind_ephys_utils.adapters.xarray import (
+    binned_to_xarray,
+    ragged_to_xarray,
+    xarray_to_binned,
+    xarray_to_ragged,
+)
+from aind_ephys_utils.types import BinnedSpikes, RaggedSpikes
+
+
+class BinnedRoundTripTest(unittest.TestCase):
+    def setUp(self):
+        self.binned = BinnedSpikes(
+            data=np.arange(24, dtype=float).reshape(2, 3, 4),
+            time=np.array([0.0, 0.1, 0.2, 0.3]),
+            trial_meta={"condition": np.array(["A", "B"])},
+            unit_meta={
+                "unit_id": np.array([10, 20, 30]),
+                "region": np.array(["V1", "M1", "V1"]),
+            },
+        )
+
+    def test_round_trip(self):
+        da = binned_to_xarray(self.binned)
+        recovered = xarray_to_binned(da)
+        assert_array_equal(recovered.data, self.binned.data)
+        assert_array_equal(recovered.time, self.binned.time)
+
+    def test_metadata_preserved(self):
+        da = binned_to_xarray(self.binned)
+        recovered = xarray_to_binned(da)
+        assert_array_equal(
+            recovered.trial_meta["condition"], ["A", "B"]
+        )
+        assert_array_equal(
+            recovered.unit_meta["region"], ["V1", "M1", "V1"]
+        )
+
+    def test_xarray_has_correct_dims(self):
+        da = binned_to_xarray(self.binned)
+        self.assertEqual(da.dims, ("trial", "unit", "time"))
+        self.assertEqual(da.shape, (2, 3, 4))
+
+    def test_unit_id_as_coord(self):
+        da = binned_to_xarray(self.binned)
+        assert_array_equal(da.coords["unit"].values, [10, 20, 30])
+
+    def test_metadata_as_coords(self):
+        da = binned_to_xarray(self.binned)
+        self.assertIn("condition", da.coords)
+        assert_array_equal(da.coords["condition"].values, ["A", "B"])
+        self.assertIn("region", da.coords)
+        assert_array_equal(da.coords["region"].values, ["V1", "M1", "V1"])
+
+    def test_from_xarray_transposes(self):
+        """Non-canonical dim order should be handled."""
+        da = xr.DataArray(
+            data=np.zeros((3, 4, 2)),
+            dims=("unit", "time", "trial"),
+            coords={
+                "unit": [0, 1, 2],
+                "time": [0.0, 0.1, 0.2, 0.3],
+                "trial": [0, 1],
+            },
+        )
+        bs = xarray_to_binned(da)
+        self.assertEqual(bs.data.shape, (2, 3, 4))
+
+
+class RaggedRoundTripTest(unittest.TestCase):
+    def setUp(self):
+        self.ragged = RaggedSpikes(
+            spike_times=[
+                [np.array([0.1, 0.2]), np.array([0.3])],
+                [np.array([0.5]), np.array([0.6, 0.7, 0.8])],
+            ],
+            n_trials=2,
+            n_units=2,
+            time_window=(-0.5, 1.0),
+            trial_meta={"condition": np.array(["A", "B"])},
+            unit_meta={
+                "unit_id": np.array([10, 20]),
+                "region": np.array(["V1", "M1"]),
+            },
+        )
+
+    def test_round_trip(self):
+        da = ragged_to_xarray(self.ragged)
+        recovered = xarray_to_ragged(da)
+        self.assertEqual(recovered.n_trials, 2)
+        self.assertEqual(recovered.n_units, 2)
+        assert_allclose(
+            recovered.spike_times[0][0], self.ragged.spike_times[0][0]
+        )
+        assert_allclose(
+            recovered.spike_times[1][1], self.ragged.spike_times[1][1]
+        )
+
+    def test_time_window_preserved(self):
+        da = ragged_to_xarray(self.ragged)
+        recovered = xarray_to_ragged(da)
+        self.assertEqual(recovered.time_window, (-0.5, 1.0))
+
+    def test_metadata_preserved(self):
+        da = ragged_to_xarray(self.ragged)
+        recovered = xarray_to_ragged(da)
+        assert_array_equal(
+            recovered.trial_meta["condition"], ["A", "B"]
+        )
+        assert_array_equal(
+            recovered.unit_meta["region"], ["V1", "M1"]
+        )
+
+    def test_xarray_has_correct_structure(self):
+        da = ragged_to_xarray(self.ragged)
+        self.assertEqual(da.dims, ("trial", "unit"))
+        self.assertEqual(da.dtype, object)
+        self.assertEqual(da.shape, (2, 2))
+
+    def test_none_entries_handled(self):
+        """None entries in ragged xarray should become empty arrays."""
+        data = np.empty((2, 1), dtype=object)
+        data[0, 0] = np.array([1.0, 2.0])
+        data[1, 0] = None
+        da = xr.DataArray(
+            data, dims=("trial", "unit"),
+            coords={"trial": [0, 1], "unit": [0]},
+        )
+        rs = xarray_to_ragged(da)
+        assert_allclose(rs.spike_times[0][0], [1.0, 2.0])
+        self.assertEqual(rs.spike_times[1][0].size, 0)
+
+
+class InteropMethodsTest(unittest.TestCase):
+    """Test .to_xarray() and .from_xarray() on the dataclass types."""
+
+    def test_binned_to_xarray(self):
+        bs = BinnedSpikes(
+            data=np.zeros((2, 3, 4)),
+            time=np.arange(4) * 0.1,
+        )
+        da = bs.to_xarray()
+        self.assertIsInstance(da, xr.DataArray)
+        self.assertEqual(da.dims, ("trial", "unit", "time"))
+
+    def test_binned_from_xarray(self):
+        da = xr.DataArray(
+            data=np.zeros((2, 3, 4)),
+            dims=("trial", "unit", "time"),
+            coords={
+                "trial": [0, 1],
+                "unit": [0, 1, 2],
+                "time": [0.0, 0.1, 0.2, 0.3],
+            },
+        )
+        bs = BinnedSpikes.from_xarray(da)
+        self.assertEqual(bs.data.shape, (2, 3, 4))
+
+    def test_ragged_to_xarray(self):
+        rs = RaggedSpikes(
+            spike_times=[[np.array([0.1, 0.2])]],
+            n_trials=1,
+            n_units=1,
+        )
+        da = rs.to_xarray()
+        self.assertIsInstance(da, xr.DataArray)
+        self.assertEqual(da.dims, ("trial", "unit"))
+
+    def test_ragged_from_xarray(self):
+        data = np.empty((1, 1), dtype=object)
+        data[0, 0] = np.array([0.1, 0.2])
+        da = xr.DataArray(
+            data, dims=("trial", "unit"),
+            coords={"trial": [0], "unit": [0]},
+        )
+        rs = RaggedSpikes.from_xarray(da)
+        self.assertEqual(rs.n_trials, 1)
+        assert_allclose(rs.spike_times[0][0], [0.1, 0.2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xarray_ops.py
+++ b/tests/test_xarray_ops.py
@@ -1,0 +1,528 @@
+"""Tests for the xarray ops layer (xarray.py).
+
+Each wrapper is tested for correctness, coord preservation, and
+consistency with the corresponding core function.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import xarray as xr
+from numpy.testing import assert_allclose, assert_array_equal
+
+from aind_ephys_utils.standards.conventions import C
+from aind_ephys_utils.xarray import (
+    align,
+    baseline,
+    bin,
+    normalize,
+    psth,
+    restrict,
+    smooth,
+)
+
+
+# ------------------------------------------------------------------
+# Fixture helpers
+# ------------------------------------------------------------------
+
+
+def _make_dense_da(
+    n_trials: int = 3,
+    n_units: int = 2,
+    n_time: int = 50,
+    dt: float = 0.01,
+    seed: int = 42,
+) -> xr.DataArray:
+    """Standard (trial, unit, time) DataArray with non-index coords."""
+    rng = np.random.default_rng(seed)
+    data = rng.standard_normal((n_trials, n_units, n_time))
+    time = np.arange(n_time) * dt
+    return xr.DataArray(
+        data,
+        dims=(C.trial, C.unit, C.time),
+        coords={
+            C.trial: np.arange(n_trials),
+            C.unit: np.arange(n_units),
+            C.time: time,
+            "condition": (
+                C.trial,
+                np.array([["A", "B"][i % 2] for i in range(n_trials)]),
+            ),
+            "region": (C.unit, np.array([["V1", "M1"][i % 2] for i in range(n_units)])),
+        },
+        attrs={"source": "test"},
+    )
+
+
+def _make_ragged_da(
+    n_trials: int = 2,
+    n_units: int = 2,
+    seed: int = 42,
+) -> xr.DataArray:
+    """Ragged (trial, unit) DataArray with object dtype."""
+    rng = np.random.default_rng(seed)
+    data = np.empty((n_trials, n_units), dtype=object)
+    for t in range(n_trials):
+        for u in range(n_units):
+            n_spikes = rng.integers(5, 20)
+            data[t, u] = np.sort(rng.uniform(-0.5, 1.0, n_spikes))
+    return xr.DataArray(
+        data,
+        dims=(C.trial, C.unit),
+        coords={
+            C.trial: np.arange(n_trials),
+            C.unit: np.arange(n_units),
+        },
+        attrs={C.attr_valid_intervals: [(-0.5, 1.0)]},
+    )
+
+
+def _make_events(
+    anchor_times: list[float],
+    event_name: str = "stim",
+) -> xr.Dataset:
+    """Events dataset for align tests."""
+    n_trials = len(anchor_times)
+    return xr.Dataset(
+        {"t": (("trial", "event"), np.array(anchor_times).reshape(-1, 1))},
+        coords={
+            "trial": np.arange(n_trials),
+            "event": [event_name],
+        },
+    )
+
+
+# ------------------------------------------------------------------
+# smooth
+# ------------------------------------------------------------------
+
+
+class SmoothTest(unittest.TestCase):
+    def test_shape_preserved(self):
+        da = _make_dense_da()
+        out = smooth(da, sigma=0.03)
+        self.assertEqual(out.dims, da.dims)
+        self.assertEqual(out.shape, da.shape)
+
+    def test_coords_preserved(self):
+        da = _make_dense_da()
+        out = smooth(da, sigma=0.03)
+        assert_array_equal(
+            out.coords["condition"].values, da.coords["condition"].values
+        )
+        assert_array_equal(out.coords["region"].values, da.coords["region"].values)
+
+    def test_attrs_preserved(self):
+        da = _make_dense_da()
+        out = smooth(da, sigma=0.03)
+        self.assertEqual(out.attrs["source"], "test")
+
+    def test_gaussian_changes_data(self):
+        da = _make_dense_da()
+        out = smooth(da, sigma=0.03)
+        self.assertFalse(np.array_equal(out.values, da.values))
+
+    def test_boxcar(self):
+        da = _make_dense_da()
+        out = smooth(da, method="boxcar", window=0.03)
+        self.assertEqual(out.shape, da.shape)
+
+    def test_non_canonical_dim_order(self):
+        da = _make_dense_da().transpose(C.unit, C.time, C.trial)
+        out = smooth(da, sigma=0.03)
+        self.assertEqual(out.dims, (C.unit, C.time, C.trial))
+        self.assertEqual(out.shape, da.shape)
+
+    def test_missing_dim_raises(self):
+        da = _make_dense_da()
+        with self.assertRaises(ValueError):
+            smooth(da, sigma=0.03, dim="channel")
+
+
+# ------------------------------------------------------------------
+# baseline
+# ------------------------------------------------------------------
+
+
+class BaselineTest(unittest.TestCase):
+    def test_subtract(self):
+        data = np.array([[[1.0, 2.0, 3.0, 4.0]]])
+        time = np.array([0.0, 1.0, 2.0, 3.0])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit, C.time),
+            coords={C.trial: [0], C.unit: [0], C.time: time},
+        )
+        out = baseline(da, window=(0.0, 1.0), mode="subtract")
+        assert_allclose(out.values[0, 0], [-0.5, 0.5, 1.5, 2.5])
+
+    def test_divide(self):
+        data = np.array([[[2.0, 4.0, 6.0, 8.0]]])
+        time = np.array([0.0, 1.0, 2.0, 3.0])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit, C.time),
+            coords={C.trial: [0], C.unit: [0], C.time: time},
+        )
+        out = baseline(da, window=(0.0, 1.0), mode="divide")
+        assert_allclose(out.values[0, 0], [2.0 / 3.0, 4.0 / 3.0, 2.0, 8.0 / 3.0])
+
+    def test_zscore_zero_std(self):
+        data = np.array([[[5.0, 5.0, 10.0, 15.0]]])
+        time = np.array([0.0, 1.0, 2.0, 3.0])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit, C.time),
+            coords={C.trial: [0], C.unit: [0], C.time: time},
+        )
+        out = baseline(da, window=(0.0, 1.0), mode="zscore")
+        self.assertFalse(np.any(np.isnan(out.values)))
+        assert_allclose(out.values[0, 0, :2], [0.0, 0.0])
+
+    def test_coords_preserved(self):
+        da = _make_dense_da()
+        out = baseline(da, window=(0.0, 0.2))
+        assert_array_equal(
+            out.coords["condition"].values, da.coords["condition"].values
+        )
+        assert_array_equal(out.coords["region"].values, da.coords["region"].values)
+
+    def test_empty_window_raises(self):
+        da = _make_dense_da()
+        with self.assertRaises(ValueError):
+            baseline(da, window=(5.0, 6.0))
+
+
+# ------------------------------------------------------------------
+# normalize
+# ------------------------------------------------------------------
+
+
+class NormalizeTest(unittest.TestCase):
+    def test_zscore_across_trials(self):
+        da = _make_dense_da(n_trials=10)
+        out = normalize(da, dim=C.trial, method="zscore")
+        assert_allclose(out.values.mean(axis=0), 0.0, atol=1e-10)
+
+    def test_minmax_range(self):
+        da = _make_dense_da(n_trials=10)
+        out = normalize(da, dim=C.trial, method="minmax")
+        self.assertGreaterEqual(out.values.min(), -1e-10)
+        self.assertLessEqual(out.values.max(), 1.0 + 1e-10)
+
+    def test_zero_variance(self):
+        data = np.ones((5, 2, 10))
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit, C.time),
+            coords={C.trial: range(5), C.unit: range(2), C.time: range(10)},
+        )
+        out = normalize(da, dim=C.trial, method="zscore")
+        self.assertFalse(np.any(np.isnan(out.values)))
+        assert_allclose(out.values, 0.0)
+
+    def test_multi_dim(self):
+        data = np.ones((5, 3, 10)) * 3.0
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit, C.time),
+            coords={C.trial: range(5), C.unit: range(3), C.time: range(10)},
+        )
+        out = normalize(da, dim=(C.trial, C.time), method="zscore")
+        assert_allclose(out.values, 0.0)
+
+    def test_unknown_dim_raises(self):
+        da = _make_dense_da()
+        with self.assertRaises(ValueError):
+            normalize(da, dim="channel")
+
+    def test_preserves_original_dim_order(self):
+        da = _make_dense_da().transpose(C.unit, C.time, C.trial)
+        out = normalize(da, dim=C.trial, method="zscore")
+        self.assertEqual(out.dims, (C.unit, C.time, C.trial))
+
+
+# ------------------------------------------------------------------
+# psth
+# ------------------------------------------------------------------
+
+
+class PsthTest(unittest.TestCase):
+    def test_mean_removes_trial_dim(self):
+        da = _make_dense_da()
+        out = psth(da, method="mean")
+        self.assertNotIn(C.trial, out.dims)
+        self.assertEqual(out.shape, (da.sizes[C.unit], da.sizes[C.time]))
+
+    def test_median(self):
+        data = np.array(
+            [
+                [[1.0, 2.0]],
+                [[3.0, 4.0]],
+                [[5.0, 6.0]],
+            ]
+        )
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit, C.time),
+            coords={C.trial: range(3), C.unit: [0], C.time: [0.0, 1.0]},
+        )
+        out = psth(da, method="median")
+        assert_allclose(out.values, [[3.0, 4.0]])
+
+    def test_with_labels(self):
+        data = np.array(
+            [
+                [[1.0], [2.0]],
+                [[3.0], [4.0]],
+                [[5.0], [6.0]],
+                [[7.0], [8.0]],
+            ]
+        )
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit, C.time),
+            coords={C.trial: range(4), C.unit: [0, 1], C.time: [0.0]},
+        )
+        labels = np.array(["A", "B", "A", "B"])
+        out = psth(da, labels=labels)
+        # Group A: trials 0, 2
+        assert_allclose(out.sel({C.trial: "A"}).values, [[(1 + 5) / 2], [(2 + 6) / 2]])
+        # Group B: trials 1, 3
+        assert_allclose(out.sel({C.trial: "B"}).values, [[(3 + 7) / 2], [(4 + 8) / 2]])
+
+    def test_unit_coords_survive(self):
+        da = _make_dense_da()
+        out = psth(da)
+        self.assertIn(C.unit, out.coords)
+        assert_array_equal(out.coords[C.unit].values, da.coords[C.unit].values)
+        # Non-index coord on unit dim should survive too
+        self.assertIn("region", out.coords)
+
+
+# ------------------------------------------------------------------
+# restrict
+# ------------------------------------------------------------------
+
+
+class RestrictTest(unittest.TestCase):
+    def test_dense_restrict(self):
+        da = _make_dense_da(n_time=10, dt=1.0)
+        out = restrict(da, (2.0, 5.0))
+        assert_array_equal(out.coords[C.time].values, [2.0, 3.0, 4.0, 5.0])
+        self.assertEqual(out.sizes[C.time], 4)
+
+    def test_dense_coords_preserved(self):
+        da = _make_dense_da(n_time=10, dt=1.0)
+        out = restrict(da, (2.0, 5.0))
+        assert_array_equal(
+            out.coords["condition"].values, da.coords["condition"].values
+        )
+
+    def test_ragged_restrict(self):
+        da = _make_ragged_da()
+        out = restrict(da, (0.0, 0.5))
+        self.assertEqual(out.dtype, object)
+        for t in range(out.sizes[C.trial]):
+            for u in range(out.sizes[C.unit]):
+                arr = out.values[t, u]
+                if arr.size > 0:
+                    self.assertGreaterEqual(arr.min(), 0.0)
+                    self.assertLessEqual(arr.max(), 0.5)
+
+
+# ------------------------------------------------------------------
+# bin
+# ------------------------------------------------------------------
+
+
+class BinTest(unittest.TestCase):
+    def test_basic_binning(self):
+        data = np.empty((1, 1), dtype=object)
+        data[0, 0] = np.array([0.05, 0.15])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit),
+            coords={C.trial: [0], C.unit: [0]},
+        )
+        out = bin(da, dt=0.1, window=(0.0, 0.3), output="count")
+        self.assertEqual(out.dims, (C.trial, C.unit, C.time))
+        self.assertEqual(out.shape, (1, 1, 3))
+        assert_allclose(out.values[0, 0], [1.0, 1.0, 0.0])
+
+    def test_rate_vs_count(self):
+        data = np.empty((1, 1), dtype=object)
+        data[0, 0] = np.array([0.05, 0.15])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit),
+            coords={C.trial: [0], C.unit: [0]},
+        )
+        rate = bin(da, dt=0.1, window=(0.0, 0.3), output="rate")
+        count = bin(da, dt=0.1, window=(0.0, 0.3), output="count")
+        assert_allclose(rate.values, count.values / 0.1)
+
+    def test_window_from_attrs(self):
+        da = _make_ragged_da()
+        out = bin(da, dt=0.1)
+        self.assertIn(C.time, out.dims)
+
+    def test_non_object_raises(self):
+        da = _make_dense_da()
+        with self.assertRaises(ValueError):
+            bin(da, dt=0.1)
+
+    def test_unit_only(self):
+        data = np.empty((2,), dtype=object)
+        data[0] = np.array([0.05, 0.15])
+        data[1] = np.array([0.25])
+        da = xr.DataArray(
+            data,
+            dims=(C.unit,),
+            coords={C.unit: [0, 1]},
+        )
+        out = bin(da, dt=0.1, window=(0.0, 0.3), output="count")
+        self.assertEqual(out.dims, (C.unit, C.time))
+        self.assertEqual(out.shape, (2, 3))
+
+    def test_trial_only(self):
+        data = np.empty((2,), dtype=object)
+        data[0] = np.array([0.05, 0.15])
+        data[1] = np.array([0.25])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial,),
+            coords={C.trial: [0, 1]},
+        )
+        out = bin(da, dt=0.1, window=(0.0, 0.3), output="count")
+        self.assertEqual(out.dims, (C.trial, C.time))
+        self.assertEqual(out.shape, (2, 3))
+
+
+# ------------------------------------------------------------------
+# align
+# ------------------------------------------------------------------
+
+
+class AlignTest(unittest.TestCase):
+    def test_basic_alignment(self):
+        # Single "trial" with all session spikes, 2 units
+        data = np.empty((1, 2), dtype=object)
+        data[0, 0] = np.arange(10, dtype=float)  # 0..9
+        data[0, 1] = np.arange(10, dtype=float) + 0.3
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit),
+            coords={C.trial: [0], C.unit: [0, 1]},
+        )
+        events = _make_events([2.0, 5.0])
+        out = align(da, events=events, to="stim", window=(-0.5, 0.5))
+        self.assertEqual(out.dims, (C.trial, C.unit))
+        self.assertEqual(out.shape, (2, 2))
+        # Trial 0 (anchor=2.0), unit 0: spike at 2.0 → 0.0
+        assert_allclose(out.values[0, 0], [0.0])
+
+    def test_events_dataarray(self):
+        data = np.empty((1, 1), dtype=object)
+        data[0, 0] = np.array([0.5, 1.5, 2.5])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit),
+            coords={C.trial: [0], C.unit: [0]},
+        )
+        events_da = xr.DataArray(
+            [[1.0]],
+            dims=("trial", "event"),
+            coords={"trial": [0], "event": ["stim"]},
+        )
+        out = align(da, events=events_da, to="stim", window=(-0.6, 0.6))
+        self.assertEqual(out.sizes[C.trial], 1)
+        assert_allclose(out.values[0, 0], [-0.5, 0.5])
+
+    def test_unit_coords_preserved(self):
+        data = np.empty((1, 2), dtype=object)
+        data[0, 0] = np.array([1.0, 2.0])
+        data[0, 1] = np.array([1.5, 2.5])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit),
+            coords={
+                C.trial: [0],
+                C.unit: ["neuron_a", "neuron_b"],
+                "region": (C.unit, ["V1", "M1"]),
+            },
+        )
+        events = _make_events([1.5])
+        out = align(da, events=events, to="stim", window=(-1.0, 1.0))
+        assert_array_equal(out.coords[C.unit].values, ["neuron_a", "neuron_b"])
+        self.assertIn("region", out.coords)
+
+    def test_invalid_window_raises(self):
+        data = np.empty((1, 1), dtype=object)
+        data[0, 0] = np.array([1.0])
+        da = xr.DataArray(
+            data,
+            dims=(C.trial, C.unit),
+            coords={C.trial: [0], C.unit: [0]},
+        )
+        events = _make_events([1.0])
+        with self.assertRaises(ValueError):
+            align(da, events=events, to="stim", window=(1.0, -1.0))
+
+
+# ------------------------------------------------------------------
+# Consistency with core
+# ------------------------------------------------------------------
+
+
+class ConsistencyTest(unittest.TestCase):
+    def test_smooth_matches_core(self):
+        from aind_ephys_utils import core
+
+        da = _make_dense_da()
+        dt = core.infer_dt(da.coords[C.time].values.astype(float))
+        xr_result = smooth(da, sigma=0.03)
+        np_result = core.smooth(da.values.astype(float), dt, sigma=0.03)
+        assert_allclose(xr_result.values, np_result)
+
+    def test_baseline_matches_core(self):
+        from aind_ephys_utils import core
+
+        da = _make_dense_da()
+        time = da.coords[C.time].values.astype(float)
+        xr_result = baseline(da, window=(0.0, 0.2), mode="subtract")
+        np_result = core.baseline(
+            da.values.astype(float), time, (0.0, 0.2), mode="subtract"
+        )
+        assert_allclose(xr_result.values, np_result)
+
+
+# ------------------------------------------------------------------
+# .pipe() chaining
+# ------------------------------------------------------------------
+
+
+class PipeChainTest(unittest.TestCase):
+    def test_full_pipeline(self):
+        da = _make_dense_da(n_trials=4, n_time=100)
+        labels = np.array(["A", "B", "A", "B"])
+        result = (
+            da.pipe(smooth, sigma=0.03)
+            .pipe(baseline, window=(0.0, 0.2))
+            .pipe(normalize, dim=C.trial)
+            .pipe(psth, labels=labels)
+        )
+        # Should have trial dim replaced by group labels
+        self.assertIn(C.trial, result.dims)
+        self.assertEqual(result.sizes[C.trial], 2)
+        assert_array_equal(result.coords[C.trial].values, ["A", "B"])
+        # unit and time dims should survive
+        self.assertIn(C.unit, result.dims)
+        self.assertIn(C.time, result.dims)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Architecture: core/ + xarray.py + types

This document describes the layered architecture on the `core` branch. It is a **limited rewrite** of 7 of the 10 public operations in `ops/` to test the pattern. The remaining 3 (`reduce`, `gpfa`, `pseudopop`) are not converted.

## Scope

`ops/` exposes 10 public functions. This branch converts 7 to the new layered architecture:

| ops/ function | Converted? | core/ | xarray.py | Notes |
|---------------|:----------:|-------|-----------|-------|
| `smooth` | yes | `core.smooth` | `xarray.smooth` | |
| `baseline` | yes | `core.baseline` | `xarray.baseline` | |
| `normalize` | yes | `core.normalize` | `xarray.normalize` | |
| `psth` | yes | `core.psth` | `xarray.psth` | |
| `restrict` | yes | `core.restrict_dense`, `core.restrict_ragged` | `xarray.restrict` | |
| `bin` | yes | `core.bin_spikes` | `xarray.bin` | |
| `align` | yes | `core.align` | `xarray.align` | |
| `reduce` | no | — | — | 7 methods behind 17-param dispatch; stacking logic is the substance |
| `gpfa` | no | — | — | 701 lines vendored from Elephant; could be a dependency instead |
| `pseudopop` | no | — | — | Inherently xarray (`xr.concat` + groupby) |

The ops/ originals for the 7 converted functions (918 lines) are still present because consumers (accessor, plots, dataframe adapter) import from ops/. They would be removed if the architecture were fully adopted.

## Architecture

Four layers, each with a single responsibility:

1. **`core/`** -- pure numpy operations with a fixed axis convention
2. **`types.py`** -- data containers (`RaggedSpikes`, `BinnedSpikes`) with constructors and interop
3. **`adapters/xarray.py`** -- bidirectional conversion between types and xarray DataArrays
4. **`xarray.py`** -- DataArray-in, DataArray-out wrappers with `.pipe()` chaining

The layers are additive. A numpy-only user needs only `core/`. An xarray user needs only `xarray.py`. The types and adapters are optional infrastructure for structured data and framework interop.

## Layer 1: `core/` -- pure numpy

Seven modules. No xarray dependency. Fixed axis convention:

- **Dense data**: always `(trial, unit, time)`
- **Ragged data**: `spike_times[trial][unit]` -- a 1-D float array per cell

No `dim=` parameters. Every function knows which axis is which.

| Module | Public API |
|--------|-----------|
| `smooth.py` | `smooth(data, dt, ...)`, `convolve_1d(data, kernel, ...)`, `make_kernel(dt, ...)`, `infer_dt(time)` |
| `baseline.py` | `baseline(data, time, window, mode=)` |
| `normalize.py` | `normalize(data, across=, method=)` |
| `psth.py` | `psth(data, method=, labels=)` |
| `restrict.py` | `restrict_dense(data, time, window)`, `restrict_ragged(spike_times, window)` |
| `bin.py` | `bin_spikes(spike_times, dt, window, output=)`, `make_bin_edges(dt, window)` |
| `align.py` | `align(spike_times, anchor_times, window)`, `align_unit(spike_times, anchor_times, window)` |

Usage:

```python
from aind_ephys_utils import core

aligned = core.align(spike_times, anchor_times, window=(-0.5, 1.0))
data, time = core.bin_spikes(aligned, dt=0.05, window=(-0.5, 1.0))
smoothed = core.smooth(data, dt=0.05, sigma=0.03)
corrected = core.baseline(smoothed, time, window=(-0.5, 0.0))
result = core.psth(corrected, labels=conditions)
```

The fixed convention eliminates axis parameters, makes composition free (all functions agree on the layout), and confines axis-transposition bugs to the boundary.

## Layer 2: `types.py` -- data containers

Two dataclasses that bundle data and metadata. No operation methods -- operations live in `core/` and `xarray.py`.

```python
@dataclass
class RaggedSpikes:
    spike_times: list[list[ndarray]]   # [trial][unit] -> 1D float
    n_trials: int
    n_units: int
    time_window: tuple[float, float] | None
    trial_meta: dict[str, ndarray]
    unit_meta: dict[str, ndarray]

@dataclass
class BinnedSpikes:
    data: ndarray                      # always (trial, unit, time)
    time: ndarray
    trial_meta: dict[str, ndarray]
    unit_meta: dict[str, ndarray]
```

Both provide:

- **`from_arrays()`** constructors. `BinnedSpikes.from_arrays` accepts an optional `axes=` parameter for transposition to canonical order.
- **`.to_xarray()` / `.from_xarray()`** interop via the adapter layer.

`RaggedSpikes.from_arrays` handles a common ingestion pattern: per-unit spike time arrays + optional anchor times for trial segmentation.

## Layer 3: `adapters/xarray.py` -- type conversion

Four functions using `standards.conventions.C` for dimension names:

- `binned_to_xarray` / `xarray_to_binned` -- dense data round-trip
- `ragged_to_xarray` / `xarray_to_ragged` -- object-dtype round-trip

These power the `.to_xarray()` / `.from_xarray()` methods on the types.

## Layer 4: `xarray.py` -- xarray ops

DataArray-in, DataArray-out wrappers. Seven public functions: `smooth`, `baseline`, `normalize`, `psth`, `restrict`, `bin`, `align`.

Each wrapper uses the simplest approach for its operation:

| Function | Strategy | Why |
|----------|----------|-----|
| `smooth` | `xr.apply_ufunc` + `core.convolve_1d` | Convolution has no native xarray op |
| `baseline` | `.sel()` + `.mean()` + broadcasting | xarray handles selection, reduction, and broadcasting natively |
| `normalize` | `.mean()` / `.std()` / `.quantile()` + `.where()` | xarray broadcasting eliminates need for canonical dim ordering |
| `psth` | `.mean()` / `.median()` + `xr.concat` for groups | Reduction and concatenation are native xarray ops |
| `restrict` (dense) | `da.sel({dim: slice(...)})` | One line -- xarray's label-based selection |
| `restrict` (ragged) | unpack -> `core.restrict_ragged` -> repack | No xarray equivalent for filtering object arrays |
| `bin` | unpack -> `core.bin_spikes` -> repack | No xarray equivalent for ragged-to-dense histogramming |
| `align` | unpack -> `core.align` -> repack | No xarray equivalent for searchsorted alignment |

For simple statistical ops (baseline, normalize, psth, restrict-dense), the wrappers use xarray's own operations and don't call core at all. For structural ops (bin, align, ragged restrict), they delegate to core. Smooth uses `apply_ufunc` to call core's convolution while letting xarray handle dim transposition and coord preservation.

xarray's built-in `.pipe()` gives fluent chaining:

```python
from aind_ephys_utils.xarray import smooth, baseline, normalize, psth, align, bin

result = (
    da
    .pipe(align, events=events, to="stimulus", window=(-0.5, 1.0))
    .pipe(bin, dt=0.05)
    .pipe(smooth, sigma=0.03)
    .pipe(baseline, window=(-0.5, 0.0))
    .pipe(psth, labels=conditions)
)
```

No accessor prefix, no type conversion, full coord preservation.

## Verification

| Check | Result |
|-------|--------|
| 104 new tests (core, types, adapter, xarray ops) | All pass |
| 77 existing tests (ops, accessor, etc.) | All pass -- no regressions |
| Ruff lint | Clean |
| Ruff format | Clean |
| Core xarray isolation | No core module imports xarray |
| xarray ops consistency with core | Round-trip tests confirm identical values |

## What this delivers

**Testability.** `test_core.py` has 44 tests with zero xarray imports. Testing `baseline(np.array([[[1,2,3,4]]]), np.array([0,1,2,3]), (0,1))` is simpler than constructing a DataArray with dims, coords, and attrs.

**Numpy-direct access.** `core.smooth(data, dt, sigma=0.03)` requires knowing only numpy. This serves users who don't know xarray, headless scripts, MATLAB/Julia interop, and performance-sensitive code.

**Clean xarray experience.** `.pipe(smooth, sigma=0.03)` replaces `da.ephys.smooth(sigma=0.03)`. No accessor prefix, full coord preservation, standard xarray idiom.

**Type safety.** `RaggedSpikes` vs `BinnedSpikes` as distinct types. No runtime `infer_kind` needed for the typed path.

**Bug fixes.** Both core and xarray layers guard against division by zero in zscore baseline/normalization (the original `ops/baseline.py` did not).

## What this costs

**918 → 1,736 lines (~1.9x) for the 7 basic operations.** This is a limited rewrite of 7 operations to test the layered pattern. The ops/ originals (918 lines across smooth, baseline, normalize, psth, restrict, bin, align, utils) would be removed if the architecture were fully adopted. They remain for now because consumers (accessor, plots, dataframe adapter) haven't been migrated yet.

| Layer | Lines | What it covers |
|-------|-------|---------------|
| `core/` | 718 | 7 basic operations (pure numpy) |
| `xarray.py` | 601 | 7 xarray wrappers (hybrid: xarray-native + core) |
| `types.py` | 242 | Data containers + constructors |
| `adapters/xarray.py` | 175 | Type conversion |
| **New total** | **1,736** | |

The increase comes from two sources:

1. **Parallel implementations.** For simple statistical ops (baseline, normalize, psth), core and the xarray layer implement the same math independently -- core via numpy (`data[..., mask].mean(axis=-1)`), xarray via xarray-native ops (`da.sel(...).mean(dim=dim)`). This duplication is the price of idiomatic code in each framework. The alternative -- always unpack-to-numpy and repack -- works but fights xarray instead of using it.

2. **Infrastructure.** `__init__.py` re-exports, ragged helpers in both xarray.py and adapters, type definitions and constructors, conversion functions.

**`preserve_coords` persists.** xarray drops non-indexed coords on arithmetic (`da - mean`). This is inherent to xarray. The xarray wrappers call `_preserve_coords` after arithmetic to restore them.

**`dim=` parameters move, not disappear.** Eliminated in core (fixed axes). Reintroduced in the xarray layer because xarray users expect named dimensions.

**This covers only the easy operations.** The 7 basic operations were chosen because they benefit most from the layered pattern: simple math, clear axis conventions, and 4 of 7 (baseline, normalize, psth, restrict-dense) have xarray-native equivalents that make the hybrid approach pay off. The deferred operations (reduce, dPCA, GPFA, pseudopop — 2,168 lines in ops/) are harder:

- **Reductions** (PCA, LDA, logistic, coding direction, RRR): The math is trivial (sklearn calls). The complexity is xarray stacking/unstacking, window masking, label handling, cross-label orthogonalization. A core/ version would be simple (`pca(X_2d, n_components)`) but the xarray wrapper would still need all the stacking logic — the "hybrid" benefit disappears since there are no xarray-native equivalents for dimensionality reduction.
- **GPFA** (701 lines): Already almost entirely numpy/scipy. Easiest to move to core/.
- **dPCA** (417 lines): Vendored third-party code, already numpy.
- **pseudopop** (59 lines): Inherently xarray (`xr.concat` + groupby). No useful numpy-only version.

Converting them is not impossible, but the architectural payoff is smaller — for reductions, every path goes through unpack → sklearn/scipy → repack, so the xarray layer becomes pure plumbing rather than an idiomatic improvement.

## Scaling

**New operation (e.g., spectral analysis):** Write a core numpy function + a 10-30 line xarray wrapper. The hybrid pattern gives clear guidance: if xarray has a native way to do it (mean, std, sel), use it; if not (histogram, searchsorted, SVD), call core.

**New reduction method (e.g., UMAP):** Always goes through core -- there's no xarray-native UMAP. Every framework adapter does: extract numpy -> call core -> repackage.

**New framework adapter (e.g., pandas):** Simple ops (mean, std, slice) get framework-native implementations, 10-20 lines each. Structural ops go through core. This is the same pattern as the xarray layer.

## Deferred

The following ops/ code was not replicated in core/ + xarray.py:

| Module | Lines | Why deferred |
|--------|-------|-------------|
| `reduce.py` | 991 | 7 methods behind a 17-parameter dispatch. Core versions are trivial; the hard part is stacking/label/window logic in the xarray wrapper. |
| `gpfa.py` | 701 | Already pure numpy/scipy. Easiest to move. |
| `dpca.py` | 417 | Vendored BSD-3 code, already numpy. |
| `pseudopop.py` | 59 | Inherently xarray (`xr.concat` + groupby). No useful numpy-only form. |

Also not touched: plotting, pandas/polars adapters, `from_dataframe`, the accessor, the legacy `align` module.

## Files

```
src/aind_ephys_utils/
    core/
        __init__.py          # re-exports, documents axis convention
        align.py             # align(spike_times, anchors, window) -> [trial][unit]
        bin.py               # bin_spikes(spike_times, dt, window) -> (data, centers)
        smooth.py            # smooth(data, dt, sigma=...) -> data
        baseline.py          # baseline(data, time, window) -> data
        normalize.py         # normalize(data, across="trials") -> data
        psth.py              # psth(data, labels=...) -> data
        restrict.py          # restrict_dense / restrict_ragged
    types.py                 # BinnedSpikes, RaggedSpikes (data containers + constructors + interop)
    xarray.py                # xarray-native wrappers (hybrid: xarray ops + core for ragged)
    adapters/
        xarray.py            # to/from xarray type conversion
tests/
    test_core.py             # 44 pure numpy tests
    test_types.py            # 7 dataclass constructor tests
    test_xarray_adapter.py   # 15 round-trip tests
    test_xarray_ops.py       # 38 xarray wrapper tests
```
