### PR TITLE
ci: tag reusuable workflow

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -5,9 +5,9 @@ on:
       - main
 jobs:
   tag:
-    uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
+    uses: AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main
     secrets:
-      SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }}
+      repo-token: ${{ secrets.SERVICE_TOKEN }}
   publish:
     needs: tag
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are deprecating AllenNeuralDynamics/aind-github-actions repo and are in the process of migrating to a new workflow. This PR updates the tag workflow references that point to the old workflow.

Changes:
- Updated workflow references from AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main to AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main.
- Updated SERVICE_TOKEN to repo-token.