### PR TITLE
Add spike-train epoch and synchrony utilities

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,6 @@ exclude =
     notebooks
 max-complexity = 10
 max-line-length = 90
+# E203 (whitespace before ':') is incompatible with black's slice
+# formatting; black's docs recommend disabling it.
+extend-ignore = E203

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -18,8 +18,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: | 
-        python -m pip install -e .[dev]
+      run: |
+        python -m pip install -e .[dev] numba
     - name: Run linter checks
       run: flake8 . && interrogate .
     - name: Run tests and coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+numba = [
+    'numba>=0.59'
+]
 dev = [
     'polars',
     'black',
@@ -99,5 +102,6 @@ exclude = ["setup.py",
            "results",
            "data",
            "notebooks",
-           "scratch"]
+           "scratch",
+           "tests"]
 fail-under = 100

--- a/src/aind_ephys_utils/_numba.py
+++ b/src/aind_ephys_utils/_numba.py
@@ -1,0 +1,47 @@
+"""Lazy numba import shim used by modules that need optional JIT.
+
+Modules that JIT-compile inner kernels (``ccg``, ``spike_utils``)
+import ``njit`` and ``prange`` from here instead of from ``numba``
+directly so that ``aind-ephys-utils`` remains importable when the
+``[numba]`` extra is not installed.  Decorated functions raise a clear
+``ImportError`` at call time when numba is missing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, NoReturn, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+try:
+    from numba import njit, prange
+except ImportError:  # pragma: no cover
+
+    def njit(**kwargs: Any) -> Callable[[F], F]:
+        """Stub that raises at call time when numba is missing.
+
+        Mimics ``numba.njit``'s decorator-with-kwargs form
+        (``@njit(cache=True, parallel=True)``).  Bare ``@njit`` (no
+        parentheses) is not supported by this stub — none of the
+        in-tree consumers use that form.
+        """
+
+        def _decorator(fn: F) -> F:
+            """Return a wrapper that raises when the kernel is called."""
+
+            def _wrapper(*a: Any, **kw: Any) -> NoReturn:
+                """Raise ImportError because numba is not installed."""
+                raise ImportError(
+                    "numba is required for this kernel. Install "
+                    "with: pip install 'aind-ephys-utils[numba]'"
+                )
+
+            return _wrapper  # type: ignore[return-value]
+
+        return _decorator
+
+    prange = range
+
+
+__all__ = ["njit", "prange"]

--- a/src/aind_ephys_utils/spiketrain/__init__.py
+++ b/src/aind_ephys_utils/spiketrain/__init__.py
@@ -1,0 +1,39 @@
+"""Raw-array spike-train transforms and utilities.
+
+Functions in this subpackage operate directly on numpy arrays and lists
+of spike-time arrays (no xarray coupling).  The names re-exported here
+are the main entry points; the full surface is reachable via the
+submodules (``spiketrain.epochs``, ``spiketrain.spike_utils``).
+"""
+
+from __future__ import annotations
+
+from .epochs import (
+    add_random_offset_with_wrap,
+    concat_event_windows,
+    concat_spikes_in_epochs,
+)
+from .spike_utils import (
+    align_to_events,
+    align_to_events_exclude_trigger,
+    build_synchrony_index,
+    count_coincident_per_train,
+    count_coincident_units,
+    exclude_near,
+    near_events,
+)
+
+__all__ = [
+    # epochs
+    "concat_spikes_in_epochs",
+    "concat_event_windows",
+    "add_random_offset_with_wrap",
+    # spike_utils
+    "exclude_near",
+    "near_events",
+    "count_coincident_per_train",
+    "build_synchrony_index",
+    "count_coincident_units",
+    "align_to_events",
+    "align_to_events_exclude_trigger",
+]

--- a/src/aind_ephys_utils/spiketrain/epochs.py
+++ b/src/aind_ephys_utils/spiketrain/epochs.py
@@ -1,0 +1,227 @@
+"""Epoch-based spike time manipulation utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Literal, cast
+
+import numpy as np
+
+
+def concat_spikes_in_epochs(  # noqa: C901
+    spike_times: Sequence[float] | np.ndarray,
+    epochs: Iterable[tuple[float, float]] | np.ndarray,
+    *,
+    include_right: bool = False,
+    assume_sorted_spikes: bool = True,
+    assume_sorted_epochs: bool = False,
+    return_extras: bool = False,
+) -> np.ndarray | tuple[np.ndarray, dict[str, np.ndarray]]:
+    """Clip spikes to epochs, make times relative, and concatenate continuously.
+
+    Parameters
+    ----------
+    spike_times
+        1D array-like of spike times (seconds). Duplicates allowed.
+    epochs
+        Iterable of (start, end) pairs. Overlapping epochs cause spikes in the
+        overlap to appear multiple times (once per epoch).
+    include_right
+        If True, epochs are treated as [start, end]; otherwise [start, end).
+    assume_sorted_spikes
+        If True, skips sorting ``spike_times``.
+    assume_sorted_epochs
+        If True, skips sorting ``epochs`` by start time.
+    return_extras
+        If True, also returns a dict with ``orig_indices``, ``epoch_ids``,
+        ``epoch_offsets``, and ``epoch_durations``.
+
+    Returns
+    -------
+    out_times : np.ndarray
+        1D array of concatenated spike times, shifted so time is continuous
+        across epochs.
+    extras : dict
+        Only if ``return_extras=True``.
+
+    Examples
+    --------
+    >>> t = np.array([0.1, 0.3, 0.35, 0.9, 1.05, 1.2, 1.8, 2.1])
+    >>> epochs = [(0.25, 0.5), (1.0, 1.5), (1.9, 2.2)]
+    >>> out = concat_spikes_in_epochs(t, epochs)
+    >>> out
+    array([0.05, 0.1 , 0.3 , 0.45, 0.95])
+
+    Epoch durations are [0.25, 0.50, 0.30].  Cumulative offsets are
+    [0.0, 0.25, 0.75].  Per-epoch relative spikes are shifted by the
+    cumulative offset so the output is continuous.
+    """
+    t = np.asarray(spike_times, dtype=float)
+    ep = np.asarray(epochs, dtype=float)
+    if ep.ndim != 2 or ep.shape[1] != 2:
+        raise ValueError("epochs must be an array-like of (start, end) pairs")
+
+    if np.any(~np.isfinite(ep)):
+        raise ValueError("epochs contain non-finite values")
+    if np.any(ep[:, 1] < ep[:, 0]):
+        raise ValueError("each epoch must satisfy end >= start")
+
+    if not assume_sorted_epochs:
+        order_ep = np.argsort(ep[:, 0], kind="stable")
+        ep = ep[order_ep]
+
+    if assume_sorted_spikes:
+        t_sorted = t
+        sorter = None
+    else:
+        sorter = np.argsort(t, kind="stable")
+        t_sorted = t[sorter]
+
+    durations = np.maximum(0.0, ep[:, 1] - ep[:, 0])
+    offsets = np.concatenate(([0.0], np.cumsum(durations)[:-1]))
+
+    side_hi: Literal["left", "right"] = "right" if include_right else "left"
+    kept_slices: list[tuple[int, int, int]] = []
+    kept_counts: list[int] = []
+
+    for ei, (start, end) in enumerate(ep):
+        lo = np.searchsorted(t_sorted, start, side="left")
+        hi = np.searchsorted(t_sorted, end, side=side_hi)
+        if hi > lo:
+            kept_slices.append((ei, lo, hi))
+            kept_counts.append(hi - lo)
+
+    if not kept_slices:
+        out = np.empty(0, dtype=float)
+        if return_extras:
+            extras = {
+                "orig_indices": np.empty(0, dtype=int),
+                "epoch_ids": np.empty(0, dtype=int),
+                "epoch_offsets": offsets,
+                "epoch_durations": durations,
+            }
+            return out, extras
+        return out
+
+    total = int(np.sum(kept_counts))
+    out = np.empty(total, dtype=float)
+    out_epoch_ids = np.empty(total, dtype=int)
+    orig_idx = np.empty(total, dtype=int)
+
+    pos = 0
+    for ei, lo, hi in kept_slices:
+        seg = t_sorted[lo:hi]
+        rel = (seg - ep[ei, 0]) + offsets[ei]
+        n = hi - lo
+        out[pos : pos + n] = rel
+        out_epoch_ids[pos : pos + n] = ei
+        if sorter is None:
+            orig_idx[pos : pos + n] = np.arange(lo, hi)
+        else:
+            orig_idx[pos : pos + n] = sorter[lo:hi]
+        pos += n
+
+    if return_extras:
+        extras = {
+            "orig_indices": orig_idx,
+            "epoch_ids": out_epoch_ids,
+            "epoch_offsets": offsets,
+            "epoch_durations": durations,
+        }
+        return out, extras
+    return out
+
+
+def concat_event_windows(
+    spike_times_by_unit: list[np.ndarray],
+    events: np.ndarray,
+    window: tuple[float, float],
+    *,
+    shuffle: bool = False,
+    rng: np.random.Generator | None = None,
+) -> list[np.ndarray]:
+    """Concatenate spike trains clipped to windows around events.
+
+    For each unit, clips spikes to ``[event + window[0], event + window[1])``
+    for every event, converts to relative time within each window, and
+    stitches them into one continuous train.
+
+    Parameters
+    ----------
+    spike_times_by_unit
+        List of sorted spike time arrays, one per unit.
+    events
+        1-D array of event times (seconds).
+    window
+        ``(start, end)`` relative to each event (seconds).
+    shuffle
+        If ``True``, randomly permute the event order before alignment
+        (useful for generating surrogate data).
+    rng
+        NumPy random generator for shuffling.  Ignored when ``shuffle=False``.
+
+    Returns
+    -------
+    list[np.ndarray]
+        One continuous spike train per unit with times in
+        ``[0, n_events * window_duration)``.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    ev = np.asarray(events)
+    if shuffle:
+        # Each unit gets an independent permutation so inter-unit
+        # temporal relationships are destroyed (surrogate data).
+        out: list[np.ndarray] = []
+        for st in spike_times_by_unit:
+            ev_perm = rng.permutation(ev)
+            epochs = np.column_stack(
+                [ev_perm + window[0], ev_perm + window[1]]
+            )
+            concatenated = cast(
+                np.ndarray,
+                concat_spikes_in_epochs(st, epochs, assume_sorted_epochs=True),
+            )
+            out.append(np.sort(concatenated))
+        return out
+    epochs = np.column_stack([ev + window[0], ev + window[1]])
+    return [
+        cast(np.ndarray, concat_spikes_in_epochs(st, epochs))
+        for st in spike_times_by_unit
+    ]
+
+
+def add_random_offset_with_wrap(
+    arrays: list[np.ndarray],
+    total_duration: float,
+    offset_min: float = 0,
+    offset_max: float | None = None,
+    rng: np.random.Generator | None = None,
+) -> list[np.ndarray]:
+    """Add a random offset to each array of times and wrap around ``[0, total_duration]``.
+
+    Parameters
+    ----------
+    arrays
+        List of arrays containing times in ``[0, total_duration]``.
+    total_duration
+        Maximum time value; times wrap modulo this value.
+    offset_min
+        Minimum random offset.
+    offset_max
+        Maximum random offset.  Defaults to *total_duration*.
+    rng
+        NumPy random generator.  If ``None``, a new default generator is used.
+    """
+    if offset_max is None:
+        offset_max = total_duration
+    if rng is None:
+        rng = np.random.default_rng()
+
+    shifted_arrays: list[np.ndarray] = []
+    for arr in arrays:
+        arr = np.asarray(arr)
+        offset = rng.uniform(offset_min, offset_max)
+        shifted = np.sort((arr + offset) % total_duration)
+        shifted_arrays.append(shifted)
+    return shifted_arrays

--- a/src/aind_ephys_utils/spiketrain/spike_utils.py
+++ b/src/aind_ephys_utils/spiketrain/spike_utils.py
@@ -1,0 +1,360 @@
+"""Spike train manipulation and event-alignment utilities.
+
+Most functions in this module are pure-numpy.  The synchrony-detection
+helpers (``build_synchrony_index`` / ``count_coincident_units``) require
+the ``numba`` optional dependency for the JIT-compiled inner kernel —
+they raise ``ImportError`` at call time when ``aind-ephys-utils`` is
+installed without the ``[numba]`` extra.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from aind_ephys_utils._numba import njit, prange
+
+# ---------------------------------------------------------------------------
+# Spike censoring / proximity queries
+# ---------------------------------------------------------------------------
+
+
+def exclude_near(
+    spikes: npt.NDArray, events: npt.NDArray, tol: float
+) -> npt.NDArray:
+    """Remove spikes within *tol* seconds of any event.
+
+    Parameters
+    ----------
+    spikes
+        Sorted spike times.
+    events
+        Sorted event times.
+    tol
+        Exclusion tolerance (seconds).  Spikes within ``[event - tol,
+        event + tol]`` are removed.
+
+    Returns
+    -------
+    npt.NDArray
+        Spike times with near-event spikes removed.
+    """
+    if len(events) == 0:
+        return spikes.copy()
+    idx = np.searchsorted(events, spikes)
+    near_right = (idx < len(events)) & (
+        np.abs(events[np.clip(idx, 0, len(events) - 1)] - spikes) <= tol
+    )
+    near_left = (idx > 0) & (
+        np.abs(events[np.clip(idx - 1, 0, len(events) - 1)] - spikes) <= tol
+    )
+    return spikes[~(near_right | near_left)]
+
+
+def near_events(
+    spike_times: npt.NDArray, event_times: npt.NDArray, tol: float
+) -> npt.NDArray:
+    """Boolean mask: True for spikes within *tol* of any event.
+
+    Parameters
+    ----------
+    spike_times
+        Sorted spike times.
+    event_times
+        Sorted event times.
+    tol
+        Proximity tolerance (seconds).
+
+    Returns
+    -------
+    npt.NDArray
+        Boolean array of same length as *spike_times*.
+    """
+    idx = np.searchsorted(event_times, spike_times)
+    near_right = (idx < len(event_times)) & (
+        np.abs(
+            event_times[np.clip(idx, 0, len(event_times) - 1)] - spike_times
+        )
+        <= tol
+    )
+    near_left = (idx > 0) & (
+        np.abs(
+            event_times[np.clip(idx - 1, 0, len(event_times) - 1)]
+            - spike_times
+        )
+        <= tol
+    )
+    return near_right | near_left
+
+
+def count_coincident_per_train(
+    target_spikes: npt.NDArray,
+    other_spike_trains: list[npt.NDArray],
+    tol: float,
+) -> npt.NDArray:
+    """For each spike, count how many other trains have a spike within *tol*.
+
+    Parameters
+    ----------
+    target_spikes
+        Sorted spike times for the target unit.
+    other_spike_trains
+        List of sorted spike time arrays for other units.
+    tol
+        Coincidence tolerance (seconds).
+
+    Returns
+    -------
+    npt.NDArray
+        Integer array of length ``len(target_spikes)``.  Each element
+        is the number of other trains with at least one spike within
+        *tol* of the corresponding target spike.
+    """
+    counts = np.zeros(len(target_spikes), dtype=np.int64)
+    for other_st in other_spike_trains:
+        if len(other_st) == 0:
+            continue
+        idx = np.searchsorted(other_st, target_spikes)
+        near_right = (idx < len(other_st)) & (
+            np.abs(
+                other_st[np.clip(idx, 0, len(other_st) - 1)] - target_spikes
+            )
+            <= tol
+        )
+        near_left = (idx > 0) & (
+            np.abs(
+                other_st[np.clip(idx - 1, 0, len(other_st) - 1)]
+                - target_spikes
+            )
+            <= tol
+        )
+        counts += (near_right | near_left).astype(np.int64)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Indexed synchrony detection
+# ---------------------------------------------------------------------------
+#
+# ``count_coincident_per_train`` above is O(N_target × N_others ×
+# log(avg_train_len)) per call: a Python loop dispatches one numpy
+# searchsorted per "other" train, so the cost scales with the number of
+# other units even though each individual numpy call is vectorized.
+#
+# When the same pool of "other" trains is queried for many target trains
+# (the common case in artifact-synchrony screening), there's a much
+# cheaper algorithmic shape:
+#
+#   1. Concatenate all other trains into one sorted-time array, plus a
+#      parallel array of unit indices that says which train each spike
+#      came from.  Done once.
+#   2. For each target spike, two ``np.searchsorted`` calls find the
+#      slice of the merged array within ``[t-tol, t+tol]``.  A small
+#      pass over that slice counts the *distinct* unit indices it
+#      contains.
+#
+# Per target spike that's O(log N_total) for the search + O(slice
+# length).  For N_target × N_other spike trains of average length L the
+# old approach is roughly O(N_target × N_other × log L); the indexed
+# approach is roughly O((N_target + N_other × L) × log(N_other × L))
+# amortized over all target queries against the same index.  In
+# practice the indexed approach is 10-100× faster on the population-
+# synchrony screening loop in the CCG capsule.
+#
+# The inner kernel is numba-jitted with ``parallel=True`` so the per-
+# target-spike work fans out across cores.
+
+
+def build_synchrony_index(
+    spike_trains: list[npt.NDArray],
+) -> tuple[npt.NDArray, npt.NDArray]:
+    """Concatenate spike trains into one sorted-time array + unit-index array.
+
+    Parameters
+    ----------
+    spike_trains
+        List of sorted spike-time arrays.  Each train's spikes are
+        labelled with its positional index ``0..len(spike_trains)-1`` in
+        the returned ``unit_ids`` array.
+
+    Returns
+    -------
+    sorted_times : npt.NDArray
+        All spikes from all trains, sorted ascending in time.  Shape
+        ``(N_total,)``, dtype ``float64``.
+    unit_ids : npt.NDArray
+        Parallel array giving the originating train index of each spike
+        in ``sorted_times``.  Shape ``(N_total,)``, dtype ``int32``.
+    """
+    if len(spike_trains) == 0:
+        return np.empty(0, dtype=np.float64), np.empty(0, dtype=np.int32)
+    total = sum(len(s) for s in spike_trains)
+    times = np.empty(total, dtype=np.float64)
+    uids = np.empty(total, dtype=np.int32)
+    pos = 0
+    for i, s in enumerate(spike_trains):
+        n = len(s)
+        if n == 0:
+            continue
+        times[pos : pos + n] = s
+        uids[pos : pos + n] = i
+        pos += n
+    order = np.argsort(times, kind="stable")
+    return times[order], uids[order]
+
+
+@njit(parallel=True, cache=True)
+def _count_coincident_units_kernel(
+    target_spikes: npt.NDArray,
+    sorted_times: npt.NDArray,
+    sorted_uids: npt.NDArray,
+    n_units: int,
+    tol: float,
+    exclude_uid: int,
+) -> npt.NDArray:
+    """Numba kernel: per-target-spike count of distinct unit ids in window.
+
+    For each target spike ``t`` find the slice ``sorted_times[lo:hi]``
+    within ``[t-tol, t+tol]`` (inclusive) and count how many distinct
+    values of ``sorted_uids[lo:hi]`` it contains, optionally skipping
+    ``exclude_uid``.  Parallelizes the outer loop over target spikes.
+    Annotations are informational only — numba does its own type
+    inference at JIT time.
+    """
+    n_target = target_spikes.shape[0]
+    counts = np.zeros(n_target, dtype=np.int32)
+    for i in prange(n_target):
+        t = target_spikes[i]
+        lo = np.searchsorted(sorted_times, t - tol, side="left")
+        hi = np.searchsorted(sorted_times, t + tol, side="right")
+        seen = np.zeros(n_units, dtype=np.bool_)
+        n = 0
+        for j in range(lo, hi):
+            uid = sorted_uids[j]
+            if uid == exclude_uid:
+                continue
+            if not seen[uid]:
+                seen[uid] = True
+                n += 1
+        counts[i] = n
+    return counts
+
+
+def count_coincident_units(
+    target_spikes: npt.NDArray,
+    sorted_times: npt.NDArray,
+    sorted_uids: npt.NDArray,
+    n_units: int,
+    tol: float,
+    exclude_uid: int = -1,
+) -> npt.NDArray:
+    """Per-spike count of distinct other units within ``tol`` of each target spike.
+
+    Parameters
+    ----------
+    target_spikes
+        Sorted spike times for the target unit.
+    sorted_times
+        Sorted spike times of the candidate-other-unit pool, as
+        produced by :func:`build_synchrony_index`.
+    sorted_uids
+        Parallel unit-index array, as produced by
+        :func:`build_synchrony_index`.
+    n_units
+        Number of distinct unit indices in ``sorted_uids`` (the size of
+        the unit-id space, used to size the per-spike "seen" bitmap).
+    tol
+        Coincidence tolerance in seconds.  A spike from another unit
+        within ``[t-tol, t+tol]`` of a target spike at time ``t``
+        contributes one (and only one) to that target spike's count.
+    exclude_uid
+        Optional unit index to skip (defaults to ``-1`` = no skip).
+        Use this to omit a target unit's own spikes when querying
+        against an index that includes them.
+
+    Returns
+    -------
+    npt.NDArray
+        ``int32`` array of length ``len(target_spikes)`` giving the
+        number of *distinct* other unit ids whose spike trains have at
+        least one spike within ``tol`` of each target spike.
+    """
+    return _count_coincident_units_kernel(
+        np.ascontiguousarray(target_spikes, dtype=np.float64),
+        sorted_times,
+        sorted_uids,
+        int(n_units),
+        float(tol),
+        int(exclude_uid),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Event alignment
+# ---------------------------------------------------------------------------
+
+
+def align_to_events(
+    times: npt.NDArray,
+    events: npt.NDArray,
+    window: tuple[float, float],
+) -> list[npt.NDArray]:
+    """Align *times* to *events*, return per-event relative times.
+
+    Parameters
+    ----------
+    times
+        Sorted absolute times (e.g. spike times or lick times).
+    events
+        Sorted event times to align to.
+    window
+        ``(left, right)`` in seconds relative to each event.
+
+    Returns
+    -------
+    list[npt.NDArray]
+        One array per event, containing times relative to the event
+        that fall within the window.
+    """
+    trials: list[npt.NDArray] = []
+    for ev in events:
+        lo = np.searchsorted(times, ev + window[0], side="left")
+        hi = np.searchsorted(times, ev + window[1], side="right")
+        trials.append(times[lo:hi] - ev)
+    return trials
+
+
+def align_to_events_exclude_trigger(
+    times: npt.NDArray,
+    events: npt.NDArray,
+    window: tuple[float, float],
+    tol: float = 1e-6,
+) -> list[npt.NDArray]:
+    """Align *times* to *events*, excluding the triggering event itself.
+
+    Useful when *times* and *events* overlap (e.g. aligning lick times
+    to lick events).
+
+    Parameters
+    ----------
+    times
+        Sorted absolute times.
+    events
+        Sorted event times.
+    window
+        ``(left, right)`` relative to each event.
+    tol
+        Times within *tol* of zero (the trigger) are excluded.
+
+    Returns
+    -------
+    list[npt.NDArray]
+        Per-event relative times with the trigger removed.
+    """
+    trials: list[npt.NDArray] = []
+    for ev in events:
+        lo = np.searchsorted(times, ev + window[0], side="left")
+        hi = np.searchsorted(times, ev + window[1], side="right")
+        rel = times[lo:hi] - ev
+        trials.append(rel[np.abs(rel) > tol])
+    return trials

--- a/tests/test_spike_train_utils.py
+++ b/tests/test_spike_train_utils.py
@@ -19,6 +19,13 @@ from aind_ephys_utils.spiketrain.spike_utils import (
     near_events,
 )
 
+try:
+    import numba  # noqa: F401
+
+    HAS_NUMBA = True
+except ImportError:
+    HAS_NUMBA = False
+
 
 class EpochsTest(unittest.TestCase):
     """Tests for epoch-based spike manipulation."""
@@ -102,6 +109,7 @@ class SpikeUtilsTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(trials[0], [0.3])
         np.testing.assert_array_almost_equal(trials[1], [-0.3])
 
+    @unittest.skipUnless(HAS_NUMBA, "requires the numba optional extra")
     def test_synchrony_index_counts_distinct_units(self) -> None:
         """count_coincident_units counts distinct nearby other units."""
         trains = [

--- a/tests/test_spike_train_utils.py
+++ b/tests/test_spike_train_utils.py
@@ -1,0 +1,127 @@
+"""Tests for the epochs and spike_utils spike-train utilities."""
+
+import unittest
+
+import numpy as np
+
+from aind_ephys_utils.spiketrain.epochs import (
+    add_random_offset_with_wrap,
+    concat_event_windows,
+    concat_spikes_in_epochs,
+)
+from aind_ephys_utils.spiketrain.spike_utils import (
+    align_to_events,
+    align_to_events_exclude_trigger,
+    build_synchrony_index,
+    count_coincident_per_train,
+    count_coincident_units,
+    exclude_near,
+    near_events,
+)
+
+
+class EpochsTest(unittest.TestCase):
+    """Tests for epoch-based spike manipulation."""
+
+    def test_concat_spikes_in_epochs_docstring_example(self) -> None:
+        """Clip to epochs, relativise, and stitch into continuous time."""
+        t = np.array([0.1, 0.3, 0.35, 0.9, 1.05, 1.2, 1.8, 2.1])
+        epochs = [(0.25, 0.5), (1.0, 1.5), (1.9, 2.2)]
+        out = concat_spikes_in_epochs(t, epochs)
+        np.testing.assert_array_almost_equal(out, [0.05, 0.1, 0.3, 0.45, 0.95])
+
+    def test_concat_spikes_in_epochs_extras(self) -> None:
+        """return_extras exposes provenance arrays."""
+        t = np.array([0.3, 1.05])
+        epochs = [(0.25, 0.5), (1.0, 1.5)]
+        out, extras = concat_spikes_in_epochs(t, epochs, return_extras=True)
+        self.assertEqual(out.size, 2)
+        self.assertEqual(
+            set(extras),
+            {
+                "orig_indices",
+                "epoch_ids",
+                "epoch_offsets",
+                "epoch_durations",
+            },
+        )
+        np.testing.assert_array_equal(extras["epoch_ids"], [0, 1])
+
+    def test_concat_event_windows(self) -> None:
+        """Per-unit windows around events are stitched continuously."""
+        st = [np.array([0.95, 1.05, 2.05])]
+        events = np.array([1.0, 2.0])
+        out = concat_event_windows(st, events, window=(-0.1, 0.1))
+        # Window duration 0.2; event0 (0.9, 1.1) contributes 0.95, 1.05
+        # -> rel 0.05, 0.15; event1 (1.9, 2.1) contributes 2.05 -> rel
+        # (2.05 - 1.9) + offset 0.2 = 0.35.
+        np.testing.assert_array_almost_equal(out[0], [0.05, 0.15, 0.35])
+
+    def test_add_random_offset_with_wrap_bounds(self) -> None:
+        """Offsetting with wrap keeps times in [0, total_duration)."""
+        rng = np.random.default_rng(0)
+        arrs = [np.array([0.1, 0.5, 0.9])]
+        out = add_random_offset_with_wrap(arrs, 1.0, rng=rng)
+        self.assertTrue(np.all(out[0] >= 0))
+        self.assertTrue(np.all(out[0] < 1.0))
+        self.assertEqual(out[0].size, 3)
+
+
+class SpikeUtilsTest(unittest.TestCase):
+    """Tests for proximity, alignment, and synchrony utilities."""
+
+    def test_exclude_near_and_mask(self) -> None:
+        """exclude_near drops near-event spikes; near_events masks them."""
+        spikes = np.array([0.0, 1.0, 2.0, 3.0])
+        events = np.array([1.0])
+        kept = exclude_near(spikes, events, tol=0.1)
+        np.testing.assert_array_equal(kept, [0.0, 2.0, 3.0])
+        mask = near_events(spikes, events, tol=0.1)
+        np.testing.assert_array_equal(mask, [False, True, False, False])
+
+    def test_count_coincident_per_train(self) -> None:
+        """Count how many other trains fire within tol of each spike."""
+        target = np.array([1.0])
+        others = [np.array([1.05]), np.array([5.0])]
+        counts = count_coincident_per_train(target, others, tol=0.1)
+        np.testing.assert_array_equal(counts, [1])
+
+    def test_align_to_events(self) -> None:
+        """Per-event relative times within the window."""
+        times = np.array([0.9, 1.0, 1.1, 2.0])
+        events = np.array([1.0, 2.0])
+        trials = align_to_events(times, events, window=(-0.2, 0.2))
+        self.assertEqual(len(trials), 2)
+        np.testing.assert_array_almost_equal(trials[0], [-0.1, 0.0, 0.1])
+        np.testing.assert_array_almost_equal(trials[1], [0.0])
+
+    def test_align_to_events_exclude_trigger(self) -> None:
+        """The triggering event itself is excluded from its own window."""
+        ev = np.array([1.0, 1.3])
+        trials = align_to_events_exclude_trigger(ev, ev, window=(-0.5, 0.5))
+        np.testing.assert_array_almost_equal(trials[0], [0.3])
+        np.testing.assert_array_almost_equal(trials[1], [-0.3])
+
+    def test_synchrony_index_counts_distinct_units(self) -> None:
+        """count_coincident_units counts distinct nearby other units."""
+        trains = [
+            np.array([1.0]),
+            np.array([1.05]),
+            np.array([5.0]),
+        ]
+        sorted_times, sorted_uids = build_synchrony_index(trains)
+        self.assertEqual(sorted_times.size, 3)
+        counts = count_coincident_units(
+            trains[0],
+            sorted_times,
+            sorted_uids,
+            n_units=3,
+            tol=0.1,
+            exclude_uid=0,
+        )
+        # Only unit 1 (1.05) is within 0.1 of the target spike at 1.0.
+        np.testing.assert_array_equal(counts, [1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds two raw-array spike-train utility modules to `aind_ephys_utils.spiketrain`, ported from `pl-inputs-analysis`. Mostly pure numpy; only the synchrony kernel needs numba.

### Adds
- **`spiketrain/epochs.py`** (pure numpy): `concat_spikes_in_epochs`, `concat_event_windows`, `add_random_offset_with_wrap`.
- **`spiketrain/spike_utils.py`**: `exclude_near`, `near_events`, `count_coincident_per_train`, `align_to_events`, `align_to_events_exclude_trigger` (pure numpy); `build_synchrony_index` + `count_coincident_units` (indexed pooled synchrony, 10–100× faster; numba kernel).

### Notes
- **Exports:** all of the above flattened into `spiketrain` (`from aind_ephys_utils.spiketrain import exclude_near, …`); full surface also via `spiketrain.epochs` / `spiketrain.spike_utils`.
- **numba** optional extra; only `count_coincident_units` needs it (raises on call without it) — everything else runs without numba.
- Tests: `test_spike_train_utils.py` (9). flake8 + interrogate clean. `uv run --python 3.12 --extra numba python -m unittest discover -s tests`.
- `align_to_events` overlaps the legacy `align.py`; kept separate (raw-array) — worth a later convergence pass.
- Conflicts (trivial) with PRs 1/2: `_numba.py`, `[numba]` extra, `.flake8` E203; union `spiketrain/__init__.py` with PR 3.
